### PR TITLE
Adding relative snapshot behavior of zhnist base to qcodes

### DIFF
--- a/zhinst/qcodes/base.py
+++ b/zhinst/qcodes/base.py
@@ -185,6 +185,13 @@ class ZIBaseInstrument(Instrument):
             params (dict): dictionary describing the parameter, innermost layer of nodetree_dict
 
         """
+
+        # Pass options about how the parameter snapshot should behave to qcodes.
+        # The specific driver can add these values to the nodetree as needed.
+        snapshot_exclude = params.get('snapshot_exclude', False)
+        snapshot_get = params.get('snapshot_get', True)
+        snapshot_value = params.get('snapshot_value', True)
+
         node = params["Node"].lower().replace(f"/{self._serial}/", "")
         if "Read" in params["Properties"]:
             # use controller.get("device name", "node") as getter
@@ -202,6 +209,9 @@ class ZIBaseInstrument(Instrument):
             unit=params["Unit"] if params["Unit"] != "None" else None,
             get_cmd=getter,
             set_cmd=setter,
+            snapshot_exclude=snapshot_exclude,
+            snapshot_get=snapshot_get,
+            snapshot_value=snapshot_value
         )
 
     def get_idn(self) -> Dict:

--- a/zhinst/qcodes/mfli.py
+++ b/zhinst/qcodes/mfli.py
@@ -385,6 +385,16 @@ class MFLI(ZIBaseInstrument):
         blacklist = ["scopes"]
         [self._init_submodule(key) for key in submodules if key not in blacklist]
 
+        # The following parameters are excluded from the snapshot update
+        # as they can only be captured when the instrument is in a specific state.
+        for demods in self.nodetree_dict['demods'].values():
+            demods['sample']['snapshot_get'] = False
+        for dios in self.nodetree_dict['dios'].values():
+            dios['input']['snapshot_get'] = False
+        self.nodetree_dict['auxins'][0]['sample']['snapshot_get'] = False
+        self.nodetree_dict['system']['fwlog']['snapshot_get'] = False
+        self.nodetree_dict['features']['code']['snapshot_get'] = False
+
     def _connect(self) -> None:
         """Connects the device to the data server.
 


### PR DESCRIPTION
These two commits are for the reason of fixing snapshotting of parameters in the load time of the mfli. To that end, snapshot behavior is added to the _add_parameter_from_dict in zhinst base module. The qcodes parameters snapshot can be found here [https://github.com/QCoDeS/Qcodes/blob/master/qcodes/instrument/parameter.py].
Then, problematic parameters are excluded from updating in the mfli driver for preventing snapshot update in the load time of the instrument, which takes a long time when using the original driver.