### PR TITLE
Snapshot only parameters marked as 'Setting'

### DIFF
--- a/zhinst/qcodes/base.py
+++ b/zhinst/qcodes/base.py
@@ -196,12 +196,18 @@ class ZIBaseInstrument(Instrument):
             setter = partial(self._controller._set, node)
         else:
             setter = False
+        if "Setting" in params["Properties"]:
+            snapshot_exclude = False
+        else:
+            snapshot_exclude = True
+
         instr.add_parameter(
             name=name,
             docstring=_dict_to_doc(params),
             unit=params["Unit"] if params["Unit"] != "None" else None,
             get_cmd=getter,
             set_cmd=setter,
+            snapshot_exclude=snapshot_exclude
         )
 
     def get_idn(self) -> Dict:


### PR DESCRIPTION
In qcodes every instrument and then parameter can be snapshotted to save a status of it. At the moment we snapshot all the nodes, and that result in a very slow reload. A possible solution is to blacklist the most annoying nodes as done in https://github.com/zhinst/zhinst-qcodes/pull/1
Instead, in this PR we allow snapshot only of nodes marked as 'Setting'. In this way, we don't have to maintain a list of 'good' nodes, and we instead take this information from LabOne.
@FarBo @jenshnielsen 