### PR TITLE
Add improvements for new release

### DIFF
--- a/src/zhinst/qcodes/control/drivers/base/base.py
+++ b/src/zhinst/qcodes/control/drivers/base/base.py
@@ -88,7 +88,7 @@ class ZIBaseInstrument(Instrument):
         """
         Instantiates the device controller from zhinst-toolkit, sets up the data
         server and connects the device the data server. This method is called
-        from __init__ of the base instruemnt class.
+        from __init__ of the base instrument class.
 
         """
         # use zhinst.toolkit.tools.BaseController() to interface the device
@@ -105,6 +105,47 @@ class ZIBaseInstrument(Instrument):
         self._controller.connect_device()
         self.connect_message()
         self.nodetree_dict = self._controller.nodetree._nodetree_dict
+        self._add_qcodes_params()
+
+    def _add_qcodes_params(self):
+        # add custom parameters as QCoDeS parameters
+        self.add_parameter(
+            "data_server_version",
+            unit=self._controller.data_server_version._unit,
+            docstring=self._controller.data_server_version.__repr__(),
+            get_cmd=self._controller.data_server_version,
+            set_cmd=self._controller.data_server_version,
+            label="Zurich Instruments Data Server Version",
+        )
+        self.add_parameter(
+            "firmware_version",
+            unit=self._controller.firmware_version._unit,
+            docstring=self._controller.firmware_version.__repr__(),
+            get_cmd=self._controller.firmware_version,
+            set_cmd=self._controller.firmware_version,
+            label="Revision of Device Internal Controller Software",
+        )
+        self.add_parameter(
+            "fpga_version",
+            unit=self._controller.fpga_version._unit,
+            docstring=self._controller.fpga_version.__repr__(),
+            get_cmd=self._controller.fpga_version,
+            set_cmd=self._controller.fpga_version,
+            label="HDL Firmware Revision",
+        )
+
+    def sync(self):
+        """Perform a global synchronisation between the device and the
+        data server.
+
+        Eventually wraps around the daq.sync() of the API.
+
+        Raises:
+            ToolkitError: If called and the device in not yet connected
+                to the data server.
+
+        """
+        self._controller.sync()
 
     def _init_submodule(self, key: str) -> None:
         """

--- a/src/zhinst/qcodes/control/drivers/mfli.py
+++ b/src/zhinst/qcodes/control/drivers/mfli.py
@@ -409,6 +409,12 @@ class MFLI(ZIBaseInstrument):
         self.add_submodule("daq", DAQ("daq", self, self._controller))
         self.add_submodule("sweeper", Sweeper("sweeper", self, self._controller))
 
-    def factory_reset(self) -> None:
-        """Load the factory default settings."""
-        self._controller.factory_reset()
+    def factory_reset(self, sync=True) -> None:
+        """Load the factory default settings.
+
+        Arguments:
+            sync (bool): A flag that specifies if a synchronisation
+                should be performed between the device and the data
+                server after loading the factory preset (default: True).
+        """
+        self._controller.factory_reset(sync=sync)

--- a/src/zhinst/qcodes/control/drivers/pqsc.py
+++ b/src/zhinst/qcodes/control/drivers/pqsc.py
@@ -49,6 +49,7 @@ class PQSC(ZIBaseInstrument):
 
     def _add_qcodes_params(self):
         # add custom parameters as QCoDeS parameters
+        super()._add_qcodes_params()
         self.add_parameter(
             "ref_clock",
             unit=self._controller.ref_clock._unit,
@@ -74,6 +75,22 @@ class PQSC(ZIBaseInstrument):
             label="Status Reference Clock",
         )
         self.add_parameter(
+            "repetitions",
+            unit=self._controller.repetitions._unit,
+            docstring=self._controller.repetitions.__repr__(),
+            get_cmd=self._controller.repetitions,
+            set_cmd=self._controller.repetitions,
+            label="Repetitions (Number of Triggers)",
+        )
+        self.add_parameter(
+            "holdoff",
+            unit=self._controller.holdoff._unit,
+            docstring=self._controller.holdoff.__repr__(),
+            get_cmd=self._controller.holdoff,
+            set_cmd=self._controller.holdoff,
+            label="Hold-off Time Between Triggers",
+        )
+        self.add_parameter(
             "progress",
             unit=self._controller.progress._unit,
             docstring=self._controller.progress.__repr__(),
@@ -82,11 +99,17 @@ class PQSC(ZIBaseInstrument):
             label="Fraction of Triggers Generated",
         )
 
-    def factory_reset(self) -> None:
-        """Load the factory default settings."""
-        self._controller.factory_reset()
+    def factory_reset(self, sync=True) -> None:
+        """Load the factory default settings.
 
-    def arm(self, repetitions=None, holdoff=None) -> None:
+        Arguments:
+            sync (bool): A flag that specifies if a synchronisation
+                should be performed between the device and the data
+                server after loading the factory preset (default: True).
+        """
+        self._controller.factory_reset(sync=sync)
+
+    def arm(self, sync=True, repetitions: int = None, holdoff: float = None) -> None:
         """Prepare PQSC for triggering the instruments.
 
         This method configures the execution engine of the PQSC and
@@ -99,25 +122,128 @@ class PQSC(ZIBaseInstrument):
         should be long enough such that the PQSC is still enabled when
         the feedback arrives. Otherwise, the feedback cannot be processed.
 
-        Keyword Arguments:
+        Arguments:
+            sync (bool): A flag that specifies if a synchronisation
+                should be performed between the device and the data
+                server after stopping the PQSC and clearing the
+                register bank (default: True).
             repetitions (int): If specified, the number of triggers sent
-                over ZSync ports will be set. (default: None)
+                over ZSync ports will be set (default: None).
             holdoff (double): If specified, the time between repeated
                 triggers sent over ZSync ports will be set. It has a
-                minimum value and a granularity of 100 ns. (default: None)
+                minimum value and a granularity of 100 ns
+                (default: None).
 
         """
-        self._controller.arm(repetitions=repetitions, holdoff=holdoff)
+        self._controller.arm(sync=sync, repetitions=repetitions, holdoff=holdoff)
 
-    def check_ref_clock(self, blocking=True, timeout=30) -> None:
-        """Check if reference clock is locked succesfully.
+    def run(self, sync=True) -> None:
+        """Start sending out triggers.
+
+        This method activates the trigger generation to trigger all
+        connected instruments over ZSync ports.
+
+        Arguments:
+            sync (bool): A flag that specifies if a synchronisation
+                should be performed between the device and the data
+                server after enabling the PQSC (default: True).
+
+        """
+        self._controller.run(sync=sync)
+
+    def arm_and_run(self, repetitions: int = None, holdoff: float = None) -> None:
+        """Arm the PQSC and start sending out triggers.
+
+        Simply combines the methods arm and run. A synchronisation
+        is performed between the device and the data server after
+        arming and running the PQSC.
+
+        Arguments:
+            repetitions (int): If specified, the number of triggers sent
+                over ZSync ports will be set (default: None).
+            holdoff (double): If specified, the time between repeated
+                triggers sent over ZSync ports will be set. It has a
+                minimum value and a granularity of 100 ns
+                (default: None).
+
+        """
+        self._controller.arm_and_run(repetitions=repetitions, holdoff=holdoff)
+
+    def stop(self, sync=True) -> None:
+        """Stop the trigger generation.
+
+        Arguments:
+            sync (bool): A flag that specifies if a synchronisation
+                should be performed between the device and the data
+                server after disabling the PQSC (default: True).
+
+        """
+        self._controller.stop(sync=sync)
+
+    def wait_done(self, timeout: float = 10, sleep_time: float = 0.005) -> None:
+        """Wait until trigger generation and feedback processing is done.
+
+        Arguments:
+            timeout (float): The maximum waiting time in seconds for the
+                PQSC (default: 10).
+            sleep_time (float): Time in seconds to wait between
+                requesting PQSC state
+
+        Raises:
+            TimeoutError: If the PQSC is not done sending out all
+                triggers and processing feedback before the timeout.
+
+        """
+        self._controller.wait_done(timeout=timeout, sleep_time=sleep_time)
+
+    def check_ref_clock(
+        self, blocking: bool = True, timeout: int = 30, sleep_time: int = 1
+    ) -> None:
+        """Check if reference clock is locked successfully.
 
         Keyword Arguments:
             blocking (bool): A flag that specifies if the program should
                 be blocked until the reference clock is 'locked'.
                 (default: True)
             timeout (int): Maximum time in seconds the program waits
-                when `blocking` is set to `True`. (default: 30)
+                when `blocking` is set to `True` (default: 30).
+            sleep_time (int): Time in seconds to wait between
+                requesting the reference clock status (default: 1)
+
+        Raises:
+            ToolkitError: If the device fails to lock on the reference
+                clock.
 
         """
-        self._controller.check_ref_clock(blocking=blocking, timeout=timeout)
+        self._controller.check_ref_clock(
+            blocking=blocking, timeout=timeout, sleep_time=sleep_time
+        )
+
+    def check_zsync_connection(self, ports=0, blocking=True, timeout=30) -> None:
+        """Check if the ZSync connection on the given port is successful.
+
+        This function checks the current status of the instrument
+        connected to the given port.
+
+        Arguments:
+            ports (list) or (int): The port numbers to check the ZSync
+                connection for. It can either be a single port number given
+                as integer or a list of several port numbers. (default: 0)
+            blocking (bool): A flag that specifies if the program should
+                be blocked until the status is 'connected'.
+                (default: False)
+            timeout (int): Maximum time in seconds the program waits
+                when `blocking` is set to `True`. (default: 30)
+
+        Raises:
+            ToolkitError: If ZSync connection to the instruments on the
+                specified ports is not established.
+
+        """
+        self._controller.check_zsync_connection(
+            ports=ports, blocking=blocking, timeout=timeout
+        )
+
+    @property
+    def is_running(self):
+        return self._controller.is_running

--- a/src/zhinst/qcodes/control/drivers/shfqa.py
+++ b/src/zhinst/qcodes/control/drivers/shfqa.py
@@ -3,8 +3,10 @@ from qcodes.instrument.channel import ChannelList, InstrumentChannel
 
 import zhinst.toolkit as tk
 from zhinst.toolkit.control.drivers.shfqa import (
-    Channel as SHFQA_Channel,
+    QAChannel as SHFQA_QAChannel,
     Generator as SHFQA_Generator,
+    Readout as SHFQA_Readout,
+    Integration as SHFQA_Integration,
     Sweeper as SHFQA_Sweeper,
     Scope as SHFQA_Scope,
 )
@@ -12,72 +14,77 @@ from typing import List, Dict, Union
 import numpy as np
 
 
-class Channel(InstrumentChannel):
-    """Device-specific *Channel* for the *SHFQA*."""
+class QAChannel(InstrumentChannel):
+    """Device-specific *QAChannel* for the *SHFQA*."""
 
     def __init__(self, name: str, index: int, parent_instr, parent_contr) -> None:
         super().__init__(parent_instr, name)
-        self._channel = SHFQA_Channel(parent_contr, index)
-        self._channel._init_channel_params()
-        self._add_qcodes_channel_params()
+        self._qachannel = SHFQA_QAChannel(parent_contr, index)
+        self._qachannel._init_qachannel_params()
+        self._add_qcodes_qachannel_params()
         self._init_generator()
+        self._init_readout()
         self._init_sweeper()
 
-    def _add_qcodes_channel_params(self):
+    def _add_qcodes_qachannel_params(self):
         # add custom parameters as QCoDeS parameters
         self.add_parameter(
             "input",
-            docstring=self._channel.input.__repr__(),
-            get_cmd=self._channel.input,
-            set_cmd=self._channel.input,
+            docstring=self._qachannel.input.__repr__(),
+            get_cmd=self._qachannel.input,
+            set_cmd=self._qachannel.input,
             label="Enable Signal Input",
         )
         self.add_parameter(
             "input_range",
-            unit=self._channel.input_range._unit,
-            docstring=self._channel.input_range.__repr__(),
-            get_cmd=self._channel.input_range,
-            set_cmd=self._channel.input_range,
+            unit=self._qachannel.input_range._unit,
+            docstring=self._qachannel.input_range.__repr__(),
+            get_cmd=self._qachannel.input_range,
+            set_cmd=self._qachannel.input_range,
             label="Maximal Range of the Signal Input Power",
         )
         self.add_parameter(
             "output",
-            docstring=self._channel.output.__repr__(),
-            get_cmd=self._channel.output,
-            set_cmd=self._channel.output,
+            docstring=self._qachannel.output.__repr__(),
+            get_cmd=self._qachannel.output,
+            set_cmd=self._qachannel.output,
             label="Enable Signal Output",
         )
         self.add_parameter(
             "output_range",
-            unit=self._channel.output_range._unit,
-            docstring=self._channel.output_range.__repr__(),
-            get_cmd=self._channel.output_range,
-            set_cmd=self._channel.output_range,
+            unit=self._qachannel.output_range._unit,
+            docstring=self._qachannel.output_range.__repr__(),
+            get_cmd=self._qachannel.output_range,
+            set_cmd=self._qachannel.output_range,
             label="Maximal Range of the Signal Output Power",
         )
         self.add_parameter(
             "center_freq",
-            unit=self._channel.center_freq._unit,
-            docstring=self._channel.center_freq.__repr__(),
-            get_cmd=self._channel.center_freq,
-            set_cmd=self._channel.center_freq,
+            unit=self._qachannel.center_freq._unit,
+            docstring=self._qachannel.center_freq.__repr__(),
+            get_cmd=self._qachannel.center_freq,
+            set_cmd=self._qachannel.center_freq,
             label="Center Frequency of the Analysis Band",
         )
         self.add_parameter(
             "mode",
-            docstring=self._channel.mode.__repr__(),
-            get_cmd=self._channel.mode,
-            set_cmd=self._channel.mode,
+            docstring=self._qachannel.mode.__repr__(),
+            get_cmd=self._qachannel.mode,
+            set_cmd=self._qachannel.mode,
             label="Spectroscopy or Qubit Readout Mode Selection",
         )
 
     def _init_generator(self):
         # init submodule for Generator
-        self.add_submodule("generator", Generator("generator", self, self._channel))
+        self.add_submodule("generator", Generator("generator", self, self._qachannel))
+
+    def _init_readout(self):
+        # init submodule for Readout module
+        self.add_submodule("readout", Readout("readout", self, self._qachannel))
 
     def _init_sweeper(self):
         # init submodule for Sweeper
-        self.add_submodule("sweeper", Sweeper("sweeper", self, self._channel))
+        self.add_submodule("sweeper", Sweeper("sweeper", self, self._qachannel))
 
 
 class Generator(InstrumentChannel):
@@ -93,13 +100,6 @@ class Generator(InstrumentChannel):
     def _add_qcodes_generator_params(self):
         # add custom parameters as QCoDeS parameters
         self.add_parameter(
-            "enable",
-            docstring=self._generator.enable.__repr__(),
-            get_cmd=self._generator.enable,
-            set_cmd=self._generator.enable,
-            label="Enable the Sequencer",
-        )
-        self.add_parameter(
             "dig_trigger1_source",
             docstring=self._generator.dig_trigger1_source.__repr__(),
             get_cmd=self._generator.dig_trigger1_source,
@@ -114,33 +114,72 @@ class Generator(InstrumentChannel):
             label="Digital Trigger 2 Source",
         )
         self.add_parameter(
-            "ready",
-            docstring=self._generator.ready.__repr__(),
-            get_cmd=self._generator.ready,
-            set_cmd=self._generator.ready,
-            label="Sequencer is Ready",
+            "playback_delay",
+            docstring=self._generator.playback_delay.__repr__(),
+            get_cmd=self._generator.playback_delay,
+            set_cmd=self._generator.playback_delay,
+            label="Delay for the Start of Playback",
+        )
+        self.add_parameter(
+            "single",
+            docstring=self._generator.single.__repr__(),
+            get_cmd=self._generator.single,
+            set_cmd=self._generator.single,
+            label="Single Run",
         )
 
-    def run(self) -> None:
-        """Run the generator."""
-        self._generator.run()
+    def run(self, sync=True) -> None:
+        """Run the generator.
 
-    def stop(self) -> None:
-        """Stops the generator."""
-        self._generator.stop()
-
-    def wait_done(self, timeout: float = 10) -> None:
-        """Waits until the Generator is finished.
-
-        Keyword Arguments:
-            timeout (int): The maximum waiting time in seconds for the
-                Generator (default: 10).
+        Arguments:
+            sync (bool): A flag that specifies if a synchronisation
+                should be performed between the device and the data
+                server after enabling the generator (default: True).
 
         """
-        self._generator.wait_done(timeout)
+        self._generator.run(sync=sync)
+
+    def stop(self, sync=True) -> None:
+        """Stop the generator.
+
+        Arguments:
+            sync (bool): A flag that specifies if a synchronisation
+                should be performed between the device and the data
+                server after disabling the generator (default: True).
+
+        """
+        self._generator.stop(sync=sync)
+
+    def wait_done(self, timeout: float = 10, sleep_time: float = 0.005) -> None:
+        """Wait until the generator is finished.
+
+        Arguments:
+            timeout (float): The maximum waiting time in seconds for the
+                generator (default: 10).
+            sleep_time (float): Time in seconds to wait between
+                requesting generator state
+
+        Raises:
+            ToolkitError: If the generator is running in continuous
+                mode.
+            TimeoutError: If the generator is not finished before the
+                timeout.
+
+        """
+        self._generator.wait_done(timeout=timeout, sleep_time=sleep_time)
 
     def compile(self) -> None:
-        """Compile the current SequenceProgram and load it to sequencer."""
+        """Compile the current SequenceProgram and load it to sequencer.
+
+        Raises:
+            ToolkitConnectionError: If the AWG Core has not been set up
+                yet
+            ToolkitError: if the compilation has failed or the ELF
+                upload is not successful.
+            TimeoutError: if the program upload is not completed before
+                timeout.
+
+        """
         return self._generator.compile()
 
     def reset_queue(self) -> None:
@@ -152,15 +191,35 @@ class Generator(InstrumentChannel):
 
         Arguments:
             wave (array): The waveform to be queued as a 1D numpy array.
-
-        Keyword Arguments:
             delay (int): An individual delay in seconds for this waveform
                 w.r.t. the time origin of the sequence. (default: 0)
 
         Raises:
-            Exception: If the sequence is not of type *'Custom'*.
+            ToolkitError: If the sequence is not of type *'Custom'*.
+
         """
         self._generator.queue_waveform(wave, delay=delay)
+
+    def replace_waveform(
+        self,
+        wave: Union[List, np.array],
+        i: int = 0,
+        delay: float = 0,
+    ) -> None:
+        """Replace a waveform in the queue at a given index.
+
+        Arguments:
+            wave (array): Waveform to replace current wave
+            i (int): The index of the waveform in the queue to be
+                replaced.
+            delay (int): An individual delay in seconds for this
+                waveform w.r.t. the time origin of the sequence. (default: 0)
+
+        Raises:
+            ValueError: If the given index is out of range.
+
+        """
+        self._generator.replace_waveform(wave, i=i, delay=delay)
 
     def upload_waveforms(self) -> None:
         """Upload all waveforms in the queue to the Generator.
@@ -168,7 +227,6 @@ class Generator(InstrumentChannel):
         This method only works as expected if the Sequence Program has
         been compiled beforehand.
         See :func:`compile_and_upload_waveforms(...)`.
-
         """
         self._generator.upload_waveforms()
 
@@ -192,7 +250,7 @@ class Generator(InstrumentChannel):
         They include *'sequence_type'*, *'period'*, *'repetitions'*,
         *'trigger_mode'*, *'trigger_delay'*, ...
 
-            >>> shfqa.channels[0].generator.set_sequence_params(
+            >>> shfqa.qachannels[0].generator.set_sequence_params(
             >>>     sequence_type="Custom",
             >>>     program = seqc_program_string,
             >>>     custom_params = [param1, param2],
@@ -218,6 +276,199 @@ class Generator(InstrumentChannel):
         return self._generator.sequence_params
 
 
+class Readout(InstrumentChannel):
+    """Device-specific *Readout* module for the *SHFQA*."""
+
+    def __init__(self, name: str, parent_instr, parent_contr) -> None:
+        super().__init__(parent_instr, name)
+        self._readout = SHFQA_Readout(parent_contr)
+        self._readout._init_readout_params()
+        self._add_qcodes_readout_params()
+        self._init_integrations()
+
+    def _add_qcodes_readout_params(self):
+        # add custom parameters as QCoDeS parameters
+        self.add_parameter(
+            "integration_length",
+            docstring=self._readout.integration_length.__repr__(),
+            get_cmd=self._readout.integration_length,
+            set_cmd=self._readout.integration_length,
+            label="Integration Length",
+        )
+        self.add_parameter(
+            "integration_delay",
+            docstring=self._readout.integration_delay.__repr__(),
+            get_cmd=self._readout.integration_delay,
+            set_cmd=self._readout.integration_delay,
+            label="Integration Delay",
+        )
+        self.add_parameter(
+            "result_source",
+            docstring=self._readout.result_source.__repr__(),
+            get_cmd=self._readout.result_source,
+            set_cmd=self._readout.result_source,
+            label="Result Source",
+        )
+
+    def _init_integrations(self):
+        # init submodules for Integration Units
+        channel_list = ChannelList(self, "integrations", Integration)
+        for i in range(16):
+            channel_list.append(Integration(f"integration-{i}", i, self, self._readout))
+        channel_list.lock()
+        self.add_submodule("integrations", channel_list)
+        self._readout._init_integrations()
+
+    @property
+    def is_running(self):
+        return self._readout.is_running
+
+    def arm(self, sync=True, length: int = None, averages: int = None) -> None:
+        """Prepare SHF device for readout and result acquisition.
+
+        This method enables the QA Results Acquisition and resets the
+        acquired points. Optionally, the *result length* and
+        *result averages* can be set when specified as keyword
+        arguments. If they are not specified, they are not changed.
+
+        Arguments:
+            sync (bool): A flag that specifies if a synchronisation
+                should be performed between the device and the data
+                server after stopping the SHF device and clearing the
+                register bank (default: True).
+            length (int): If specified, the length of the result vector
+                will be set before arming the readout.
+                (default: None)
+            averages (int): If specified, the result averages will be
+                set before arming the readout. (default: None)
+
+        """
+        self._readout.arm(sync=sync, length=length, averages=averages)
+
+    def run(self, sync=True) -> None:
+        """Start the result logger.
+
+        Arguments:
+            sync (bool): A flag that specifies if a synchronisation
+                should be performed between the device and the data
+                server after starting the result logger (default: True).
+
+        Raises:
+            ToolkitError: If `sync=True` and the result logger cannot
+                be started
+
+        """
+        self._readout.run(sync=sync)
+
+    def stop(self, sync=True) -> None:
+        """Stop the result logger.
+
+        Arguments:
+            sync (bool): A flag that specifies if a synchronisation
+                should be performed between the device and the data
+                server after stopping the result logger (default: True).
+
+        Raises:
+            ToolkitError: If `sync=True` and the result logger cannot
+                be stopped
+
+        """
+        self._readout.stop(sync=sync)
+
+    def wait_done(self, timeout: float = 10, sleep_time: float = 0.005) -> None:
+        """Wait until readout is finished.
+
+        Arguments:
+            timeout (float): The maximum waiting time in seconds for the
+                Readout (default: 10).
+            sleep_time (float): Time in seconds to wait between
+                requesting Readout state
+
+        Raises:
+            TimeoutError: if the readout recording is not completed
+                before timeout.
+
+        """
+        self._readout.wait_done(timeout=timeout, sleep_time=sleep_time)
+
+    def read(
+        self,
+        integrations: list = [],
+        blocking: bool = True,
+        timeout: float = 10,
+        sleep_time: float = 0.005,
+    ):
+        """Read out the measured data from the result logger.
+
+        Arguments:
+            integrations (list): The list of integrations to return the
+                data for. If no integration is specified, the method
+                will return the data for all integrations
+                (default: []).
+            blocking (bool): A flag that specifies if the program
+                should be blocked until the result logger finished
+                recording (default: True).
+            timeout (float): The maximum waiting time in seconds for the
+                Readout (default: 10).
+            sleep_time (float): Time in seconds to wait between
+                requesting Readout state
+
+        Returns:
+            An array containing the result logger data.
+
+        Raises:
+            TimeoutError: if the readout recording is not completed
+                before timeout.
+
+        """
+        return self._readout.read(
+            integrations=integrations,
+            blocking=blocking,
+            timeout=timeout,
+            sleep_time=sleep_time,
+        )
+
+
+class Integration(InstrumentChannel):
+    """Device-specific *ReadoutChannel* for the *SHFQA*."""
+
+    def __init__(self, name: str, index: int, parent_instr, parent_contr) -> None:
+        super().__init__(parent_instr, name)
+        self._integration = SHFQA_Integration(parent_contr, index)
+        self._integration._init_integration_params()
+        self._add_qcodes_integration_params()
+
+    def _add_qcodes_integration_params(self):
+        # add custom parameters as QCoDeS parameters
+        self.add_parameter(
+            "threshold",
+            unit=self._integration.threshold._unit,
+            docstring=self._integration.threshold.__repr__(),
+            get_cmd=self._integration.threshold,
+            set_cmd=self._integration.threshold,
+            label="Signal Threshold for State Discrimination",
+        )
+        self.add_parameter(
+            "result",
+            unit=self._integration.result._unit,
+            docstring=self._integration.result.__repr__(),
+            get_cmd=self._integration.result,
+            set_cmd=self._integration.result,
+            label="Result Vector Data",
+        )
+        self.add_parameter(
+            "weights",
+            unit=self._integration.weights._unit,
+            docstring=self._integration.weights.__repr__(),
+            get_cmd=self._integration.weights,
+            set_cmd=self._integration.weights,
+            label="Complex-valued Waveform of the Integration Weights",
+        )
+
+    def set_int_weights(self, weights):
+        return self._integration.set_int_weights(weights)
+
+
 class Sweeper(InstrumentChannel):
     """Device-specific *Sweeper* for the *SHFQA*."""
 
@@ -238,12 +489,20 @@ class Sweeper(InstrumentChannel):
             label="Gain of Digital Oscillator",
         )
         self.add_parameter(
+            "oscillator_freq",
+            unit=self._sweeper.oscillator_freq._unit,
+            docstring=self._sweeper.oscillator_freq.__repr__(),
+            get_cmd=self._sweeper.oscillator_freq,
+            set_cmd=self._sweeper.oscillator_freq,
+            label="Frequency of Digital Oscillator",
+        )
+        self.add_parameter(
             "integration_time",
             unit=self._sweeper.integration_time._unit,
             docstring=self._sweeper.integration_time.__repr__(),
             get_cmd=self._sweeper.integration_time,
             set_cmd=self._sweeper.integration_time,
-            label="Integration Time",
+            label="Spectroscopy Integration Time",
         )
         self.add_parameter(
             "integration_length",
@@ -251,78 +510,97 @@ class Sweeper(InstrumentChannel):
             docstring=self._sweeper.integration_length.__repr__(),
             get_cmd=self._sweeper.integration_length,
             set_cmd=self._sweeper.integration_length,
-            label="Integration Length",
+            label="Spectroscopy Integration Length",
         )
-
-    def trigger_source(self, source=None):
-        """Set or get the trigger source for the sweeper.
-
-        Keyword Arguments:
-            source (str): Trigger source of the sweeper
-                (default: None).
-
-        """
-        return self._sweeper.trigger_source(source)
+        self.add_parameter(
+            "integration_delay",
+            unit=self._sweeper.integration_delay._unit,
+            docstring=self._sweeper.integration_delay.__repr__(),
+            get_cmd=self._sweeper.integration_delay,
+            set_cmd=self._sweeper.integration_delay,
+            label="Spectroscopy Integration Delay",
+        )
+        self.add_parameter(
+            "trigger_source",
+            unit=self._sweeper.trigger_source._unit,
+            docstring=self._sweeper.trigger_source.__repr__(),
+            get_cmd=self._sweeper.trigger_source,
+            set_cmd=self._sweeper.trigger_source,
+            label="Trigger Source for the Sweeper",
+        )
 
     def trigger_level(self, level=None):
         """Set or get the trigger level for the sweeper.
 
-        Keyword Arguments:
+        Arguments:
             level (float): Trigger level of the sweeper
                 (default: None).
 
         """
-        return self._sweeper.trigger_level(level)
+        return self._sweeper.trigger_level(level=level)
 
     def trigger_imp50(self, imp50=None):
         """Set or get the trigger input impedance setting for the sweeper.
 
-        Keyword Arguments:
+        Arguments:
             imp50 (bool): Trigger input impedance selection for the
                 sweeper. When set to True, the trigger input impedance is
                 50 Ohm. When set to False, it is 1 kOhm (default: None).
 
         """
-        return self._sweeper.trigger_imp50(imp50)
+        return self._sweeper.trigger_imp50(imp50=imp50)
 
     def start_frequency(self, freq=None):
         """Set or get the start frequency for the sweeper.
 
-        Keyword Arguments:
+        Arguments:
             freq (float): Start frequency in Hz of the sweeper
                 (default: None).
 
         """
-        return self._sweeper.start_frequency(freq)
+        return self._sweeper.start_frequency(freq=freq)
 
     def stop_frequency(self, freq=None):
         """Set or get the stop frequency for the sweeper.
 
-        Keyword Arguments:
+        Arguments:
             freq (float): Stop frequency in Hz of the sweeper
                 (default: None).
 
         """
-        return self._sweeper.stop_frequency(freq)
+        return self._sweeper.stop_frequency(freq=freq)
+
+    def output_freq(self):
+        """Get the output frequency.
+
+        Returns:
+            The carrier frequency in Hz of the microwave signal at the
+            Out connector. This frequency corresponds to the sum of the
+            Center Frequency and the Offset Frequency.
+
+        """
+        return self._sweeper.output_freq()
 
     def num_points(self, num=None):
         """Set or get the number of points for the sweeper.
 
-        Keyword Arguments:
+        Arguments:
             num (int): Number of frequency points to sweep between
                 start and stop frequency values (default: None).
+
         """
-        return self._sweeper.num_points(num)
+        return self._sweeper.num_points(num=num)
 
     def mapping(self, map=None):
         """Set or get the mapping configuration for the sweeper.
 
-        Keyword Arguments:
+        Arguments:
             map (str): Mapping that specifies the distances between
                 frequency points of the sweeper. Can be either "linear"
                 or "log" (default: None).
+
         """
-        return self._sweeper.mapping(map)
+        return self._sweeper.mapping(map=map)
 
     def num_averages(self, num=None):
         """Set or get the number of averages for the sweeper.
@@ -330,46 +608,60 @@ class Sweeper(InstrumentChannel):
         Number of averages specifies how many times a frequency point
         will be measured and averaged.
 
-        Keyword Arguments:
+        Arguments:
             num (int): Number of times the sweeper measures one
                 frequency point (default: None).
+
         """
-        return self._sweeper.num_averages(num)
+        return self._sweeper.num_averages(num=num)
 
     def averaging_mode(self, mode=None):
         """Set or get the averaging mode for the sweeper.
 
-        Keyword Arguments:
-            mode (str): Averaging mode for the sweeper.
-        Can be either "pointwise" or "sweepwise".
-            "pointwise": A frequency point is measured the number of
-                times specified by the number of samples setting. In
-                other words, the same frequency point is measured
-                repeatedly until the number of samples is reached and
-                the sweeper then moves to the next frequency point.
-            "sweepwise": All frequency points are measured once from
+        Arguments:
+            mode (str): Averaging mode for the sweeper. Can be either
+                "sequential" or "cyclic" (default: None).\n
+                "sequential": A frequency point is measured the number
+                of times specified by the number of averages setting.
+                In other words, the same frequency point is measured
+                repeatedly until the number of averages is reached
+                and the sweeper then moves to the next frequency
+                point.\n
+                "cyclic": All frequency points are measured once from
                 start frequency to stop frequency. The sweeper then
                 moves back to start frequency and repeats the sweep
-                the number of times specified by the number of samples
-                setting.
-            (default: None).
+                the number of times specified by the number of
+                averages setting.
+
         """
-        return self._sweeper.averaging_mode(mode)
+        return self._sweeper.averaging_mode(mode=mode)
 
     def run(self):
-        """Perform a sweep with the specified settings."""
+        """Perform a sweep with the specified settings.
+
+        This method eventually wraps around the `run` method of
+        `zhinst.utils.shf_sweeper`
+        """
         return self._sweeper.run()
 
-    def get_result(self):
+    def read(self):
         """Get the measurement data of the last sweep.
+
+        This method eventually wraps around the `get_result` method of
+        `zhinst.utils.shf_sweeper`
 
         Returns:
              A dictionary with measurement data of the last sweep
+
         """
-        return self._sweeper.get_result()
+        return self._sweeper.read()
 
     def plot(self):
-        """Plot power over frequency for last sweep."""
+        """Plot power over frequency for last sweep.
+
+        This method eventually wraps around the `plot` method of
+        `zhinst.utils.shf_sweeper`
+        """
         return self._sweeper.plot()
 
 
@@ -384,13 +676,6 @@ class Scope(InstrumentChannel):
 
     def _add_qcodes_scope_params(self):
         # add custom parameters as QCoDeS parameters
-        self.add_parameter(
-            "enable",
-            docstring=self._scope.enable.__repr__(),
-            get_cmd=self._scope.enable,
-            set_cmd=self._scope.enable,
-            label="Enable Acquisition of Scope Shots",
-        )
         self.add_parameter(
             "channel1",
             docstring=self._scope.channel1.__repr__(),
@@ -448,34 +733,6 @@ class Scope(InstrumentChannel):
             label="Select Input Signal for Scope Channel 4",
         )
         self.add_parameter(
-            "wave1",
-            docstring=self._scope.wave1.__repr__(),
-            get_cmd=self._scope.wave1,
-            set_cmd=self._scope.wave1,
-            label="Scope Channel 1 Acquired Wave Data",
-        )
-        self.add_parameter(
-            "wave2",
-            docstring=self._scope.wave2.__repr__(),
-            get_cmd=self._scope.wave2,
-            set_cmd=self._scope.wave2,
-            label="Scope Channel 2 Acquired Wave Data",
-        )
-        self.add_parameter(
-            "wave3",
-            docstring=self._scope.wave3.__repr__(),
-            get_cmd=self._scope.wave3,
-            set_cmd=self._scope.wave3,
-            label="Scope Channel 3 Acquired Wave Data",
-        )
-        self.add_parameter(
-            "wave4",
-            docstring=self._scope.wave4.__repr__(),
-            get_cmd=self._scope.wave4,
-            set_cmd=self._scope.wave4,
-            label="Scope Channel 4 Acquired Wave Data",
-        )
-        self.add_parameter(
             "trigger_source",
             docstring=self._scope.trigger_source.__repr__(),
             get_cmd=self._scope.trigger_source,
@@ -506,87 +763,107 @@ class Scope(InstrumentChannel):
             set_cmd=self._scope.time,
             label="Time Base of the Scope",
         )
-        self.add_parameter(
-            "segments_enable",
-            unit=self._scope.segments_enable._unit,
-            docstring=self._scope.segments_enable.__repr__(),
-            get_cmd=self._scope.segments_enable,
-            set_cmd=self._scope.segments_enable,
-            label="Enable Segmented Scope Recording",
-        )
-        self.add_parameter(
-            "segments_count",
-            unit=self._scope.segments_count._unit,
-            docstring=self._scope.segments_count.__repr__(),
-            get_cmd=self._scope.segments_count,
-            set_cmd=self._scope.segments_count,
-            label="Number of Segments to Record",
-        )
-        self.add_parameter(
-            "averaging_enable",
-            unit=self._scope.averaging_enable._unit,
-            docstring=self._scope.averaging_enable.__repr__(),
-            get_cmd=self._scope.averaging_enable,
-            set_cmd=self._scope.averaging_enable,
-            label="Enable Averaged Scope Recording",
-        )
-        self.add_parameter(
-            "averaging_count",
-            unit=self._scope.averaging_count._unit,
-            docstring=self._scope.averaging_count.__repr__(),
-            get_cmd=self._scope.averaging_count,
-            set_cmd=self._scope.averaging_count,
-            label="Number of Averages",
-        )
 
-    def run(self) -> None:
-        """Runs the scope recording."""
-        self._scope.run()
+    def run(self, sync=True) -> None:
+        """Run the scope recording.
 
-    def stop(self) -> None:
-        """Stops the scope recording."""
-        self._scope.stop()
+        Arguments:
+            sync (bool): A flag that specifies if a synchronisation
+                should be performed between the device and the data
+                server after starting the scope recording
+                (default: True).
 
-    def read(self, channel=None):
+        """
+        self._scope.run(sync=sync)
+
+    def stop(self, sync=True) -> None:
+        """Stop the scope recording.
+
+        Arguments:
+            sync (bool): A flag that specifies if a synchronisation
+                should be performed between the device and the data
+                server after stopping scope recording
+                (default: True).
+
+        """
+        self._scope.stop(sync=sync)
+
+    def wait_done(self, timeout: float = 10, sleep_time: float = 0.005) -> None:
+        """Wait until the Scope recording is finished.
+
+        Arguments:
+            timeout (int): The maximum waiting time in seconds for the
+                Scope (default: 10).
+            sleep_time (float): Time in seconds to wait between
+                requesting the progress and records values
+
+        Raises:
+            ToolkitError: If the Scope recording is not done before the
+                timeout.
+
+        """
+        self._scope.wait_done(timeout=timeout, sleep_time=sleep_time)
+
+    def read(
+        self,
+        channel=None,
+        blocking: bool = True,
+        timeout: float = 10,
+        sleep_time: float = 0.005,
+    ):
         """Read out the recorded data from the specified channel of the scope.
 
         Arguments:
             channel (int): The scope channel to read the data from. If
                 no channel is specified, the method will return the data
                 for all channels.
+            blocking (bool): A flag that specifies if the program
+                should be blocked until the scope has finished
+                recording (default: True).
+            timeout (float): The maximum waiting time in seconds for the
+                Scope (default: 10).
+            sleep_time (float): Time in seconds to wait between
+                requesting the progress and records values
 
         Returns:
             A dictionary showing the recorded data and scope time.
+
+        Raises:
+            TimeoutError: if the scope recording is not completed before
+                timeout.
+
         """
-        return self._scope.read(channel)
+        return self._scope.read(
+            channel=channel, blocking=blocking, timeout=timeout, sleep_time=sleep_time
+        )
 
     def channels(self, value=None):
         """Set all Scope channels simultaneously.
 
-        Keyword Arguments:
+        Arguments:
             value (tuple): Tuple of values {'on', 'off'} for channel 1,
-            2, 3 and 4 (default: None).
+                2, 3 and 4 (default: None).
 
         Returns:
             A tuple with the states {'on', 'off'} for all input channels.
 
         """
-        return self._scope.channels(value)
+        return self._scope.channels(value=value)
 
     def input_select(self, value=None):
         """Set all Scope input signals simultaneously.
 
         Keyword Arguments:
             value (tuple): Tuple of values for input signal 1,
-            2, 3 and 4. The accepted values can be found in SHFQA
-            user manual (default: None).
+                2, 3 and 4. The accepted values can be found in SHFQA
+                user manual (default: None).
 
         Returns:
             A tuple with the selected input signal sources for all
             input channels.
 
         """
-        return self._scope.input_select(value)
+        return self._scope.input_select(value=value)
 
     def segments(self, enable=None, count=None):
         """Configure segmented Scope recording options.
@@ -598,8 +875,9 @@ class Scope(InstrumentChannel):
 
         Returns:
             A dictionary showing the enable state and segment count
+
         """
-        return self._scope.segments(enable, count)
+        return self._scope.segments(enable=enable, count=count)
 
     def averaging(self, enable=None, count=None):
         """Configure averaging options of Scope measurements.
@@ -612,8 +890,13 @@ class Scope(InstrumentChannel):
 
         Returns:
             A dictionary showing the enable state and averaging count
+
         """
-        return self._scope.averaging(enable, count)
+        return self._scope.averaging(enable=enable, count=count)
+
+    @property
+    def is_running(self):
+        return self._scope.is_running
 
 
 class SHFQA(ZIBaseInstrument):
@@ -657,25 +940,34 @@ class SHFQA(ZIBaseInstrument):
         self._controller.connect_device()
         self.connect_message()
         self.nodetree_dict = self._controller.nodetree._nodetree_dict
-        self._init_channels()
+        self._init_qachannels()
         self._init_scope()
         self._add_qcodes_params()
 
-    def _init_channels(self):
-        # init submodules for Channels
-        num_channels = self._controller._num_channels()
-        channel_list = ChannelList(self, "channels", Channel)
-        for i in range(num_channels):
-            channel_list.append(Channel(f"ch-{i}", i, self, self._controller))
+    def _init_qachannels(self):
+        # init submodules for QAChannels
+        num_qachannels = self._controller._num_qachannels()
+        channel_list = ChannelList(self, "qachannels", QAChannel)
+        for i in range(num_qachannels):
+            channel_list.append(QAChannel(f"qachannel-{i}", i, self, self._controller))
         channel_list.lock()
-        self.add_submodule("channels", channel_list)
+        self.add_submodule("qachannels", channel_list)
 
     def _init_scope(self):
-        # init submodule AWG
+        # init submodule Scope
         self.add_submodule("scope", Scope("scope", self, self._controller))
 
     def _add_qcodes_params(self):
         # add custom parameters as QCoDeS parameters
+        super()._add_qcodes_params()
+        self.add_parameter(
+            "sw_trigger",
+            unit=self._controller.sw_trigger._unit,
+            docstring=self._controller.sw_trigger.__repr__(),
+            get_cmd=self._controller.sw_trigger,
+            set_cmd=self._controller.sw_trigger,
+            label="Issue a Single Software Trigger Event",
+        )
         self.add_parameter(
             "ref_clock",
             unit=self._controller.ref_clock._unit,
@@ -700,37 +992,57 @@ class SHFQA(ZIBaseInstrument):
             set_cmd=self._controller.ref_clock_status,
             label="Status Reference Clock",
         )
-        self.add_parameter(
-            "timebase",
-            unit=self._controller.timebase._unit,
-            docstring=self._controller.timebase.__repr__(),
-            get_cmd=self._controller.timebase,
-            set_cmd=self._controller.timebase,
-            label="Minimal Time Difference Between Two Timestamps.",
-        )
 
-    def factory_reset(self) -> None:
-        """Load the factory default settings."""
-        self._controller.factory_reset()
+    def factory_reset(self, sync=True) -> None:
+        """Load the factory default settings.
+
+        Arguments:
+            sync (bool): A flag that specifies if a synchronisation
+                should be performed between the device and the data
+                server after loading the factory preset (default: True).
+
+        """
+        self._controller.factory_reset(sync=sync)
 
     def set_trigger_loopback(self):
         """Start a trigger pulse using the internal loopback.
 
-        Start a 1kHz continuous trigger pulse from marker 1 A using the
+        A 1kHz continuous trigger pulse from marker 1 A using the
         internal loopback to trigger in 1 A.
-
         """
         self._controller.set_trigger_loopback()
 
-    def check_ref_clock(self, blocking=True, timeout=30) -> None:
-        """Check if reference clock is locked succesfully.
+    def clear_trigger_loopback(self):
+        """Stop the the internal loopback trigger pulse."""
+        self._controller.clear_trigger_loopback()
 
-        Keyword Arguments:
+    def check_ref_clock(
+        self, blocking: bool = True, timeout: int = 30, sleep_time: int = 1
+    ) -> None:
+        """Check if reference clock is locked successfully.
+
+        Arguments:
             blocking (bool): A flag that specifies if the program should
                 be blocked until the reference clock is 'locked'.
                 (default: True)
             timeout (int): Maximum time in seconds the program waits
-                when `blocking` is set to `True`. (default: 30)
+                when `blocking` is set to `True` (default: 30).
+            sleep_time (int): Time in seconds to wait between
+                requesting the reference clock status (default: 1)
+
+        Raises:
+            ToolkitError: If the device fails to lock on the reference
+                clock.
 
         """
-        self._controller.check_ref_clock(blocking=blocking, timeout=timeout)
+        self._controller.check_ref_clock(
+            blocking=blocking, timeout=timeout, sleep_time=sleep_time
+        )
+
+    @property
+    def allowed_sequences(self):
+        return self._controller.allowed_sequences
+
+    @property
+    def allowed_trigger_modes(self):
+        return self._controller.allowed_trigger_modes

--- a/src/zhinst/qcodes/control/drivers/uhfli.py
+++ b/src/zhinst/qcodes/control/drivers/uhfli.py
@@ -417,6 +417,21 @@ class UHFLI(ZIBaseInstrument):
         self.add_submodule("daq", DAQ("daq", self, self._controller))
         self.add_submodule("sweeper", Sweeper("sweeper", self, self._controller))
 
-    def factory_reset(self) -> None:
-        """Load the factory default settings."""
-        self._controller.factory_reset()
+    def factory_reset(self, sync=True) -> None:
+        """Load the factory default settings.
+
+        Arguments:
+            sync (bool): A flag that specifies if a synchronisation
+                should be performed between the device and the data
+                server after loading the factory preset (default: True).
+
+        """
+        self._controller.factory_reset(sync=sync)
+
+    @property
+    def allowed_sequences(self):
+        return self._controller.allowed_sequences
+
+    @property
+    def allowed_trigger_modes(self):
+        return self._controller.allowed_trigger_modes


### PR DESCRIPTION
#### **The following changes are made in this update:**
##### **1) `ZIBaseInstrument` updates:**
* New qcodes parameters added: `data_server_version`,
`firmware_version`, `fpga_version`
* `sync` method is added to perform a global synchronisation between
the device and the data server.
##### **2) HDAWG updates:**
* New qcodes parameters added: `zsync_register_mask`,
`zsync_register_shift`, `zsync_register_offset`, `zsync_decoder_mask`,
`zsync_decoder_shift`, `zsync_decoder_offset`.
* Add `sync` argument to `run` and `stop` functions of AWG,
and to `factory_reset` function.
* Add `allowed_sequences` and `allowed_trigger_modes` attributes
##### **3) MFLI updates:**
* Add `sync` argument to `factory_reset` function.
##### **4) PQSC updates:**
* repetitions` and `holdoff` parameters are added.
* Add `sync` argument to `factory_reset` and `arm` functions.
* `run, `stop`, `arm_and_run`, `wait_done` and `check_zsync_connection`
methods are added-
* `sleep_time` argument added to `check_ref_clock` method.
* `is_running` attribute added.
##### **5) SHFQA updates:**
* `Channel` module is renamed to `QAChannel`
* `sw_trigger` parameter added
* `clear_trigger_loopback` method is added
* `sleep_time` is added to `check_ref_clock`
* `allowed_sequences` and `allowed_trigger_modes` attributes are added
* `Readout` module is added
* `ready` and `enable` parameters removed from the `Generator` module.
`playback_delay` and `single` parameters are added.
* Add `sync` argument to `run` and `stop` functions of `Generator`
* Add `sleep_time` argument to `wait_done` function of `Generator`
* Add `replace_waveform` method to `Generator`
* `oscillator_freq`, `integration_delay` and parameters are added to
`Sweeper`
* `trigger_source` method of `Sweeper` is replaced as qcodes parameter
with the same name
* `output_freq` method is added `Sweeper`
* `get_result` method of `Sweeper` is renamed to `read`
* `enable`, `wave1`, `wave2`, `wave3`, `wave4`, `segments_enable`,
`segments_count`, `averaging_enable`, `averaging_count` is removed from
`Scope`
* Add `sync` argument to `run` and `stop` functions of `Scope`
* Added `wait_done` method to `Scope`
* Added `blocking` argument to `read` method of `Scope`
* Added `is_running` attribute to `Scope`
##### **6) UHFLI updates:**
* Add `sync` argument to `factory_reset` function.
* Add `allowed_sequences` and `allowed_trigger_modes` attributes
##### **7) UHFQA updates:**
* Scope module added.
* New qcodes parameter added: `ref_clock`
* Add `sync` argument to `run` and `stop` functions of AWG,
and to `factory_reset` function.
* New method added: `enable_manual_mode`
* Add `allowed_sequences` and `allowed_trigger_modes` attributes