### PR TITLE
use the public name attribute from QCoDeS

### DIFF
--- a/src/zhinst/qcodes/control/drivers/base/base.py
+++ b/src/zhinst/qcodes/control/drivers/base/base.py
@@ -93,7 +93,7 @@ class ZIBaseInstrument(Instrument):
         """
         # use zhinst.toolkit.tools.BaseController() to interface the device
         self._controller = tk.BaseInstrument(
-            self._name,
+            self.full_name,
             self._type,
             self._serial,
             interface=self._interface,

--- a/src/zhinst/qcodes/control/drivers/hdawg.py
+++ b/src/zhinst/qcodes/control/drivers/hdawg.py
@@ -435,7 +435,7 @@ class HDAWG(ZIBaseInstrument):
 
         """
         self._controller = tk.HDAWG(
-            self._name,
+            self.full_name,
             self._serial,
             interface=self._interface,
             host=self._host,

--- a/src/zhinst/qcodes/control/drivers/mfli.py
+++ b/src/zhinst/qcodes/control/drivers/mfli.py
@@ -394,7 +394,7 @@ class MFLI(ZIBaseInstrument):
 
         """
         self._controller = tk.MFLI(
-            self._name,
+            self.full_name,
             self._serial,
             interface=self._interface,
             host=self._host,

--- a/src/zhinst/qcodes/control/drivers/pqsc.py
+++ b/src/zhinst/qcodes/control/drivers/pqsc.py
@@ -34,7 +34,7 @@ class PQSC(ZIBaseInstrument):
 
         """
         self._controller = tk.PQSC(
-            self._name,
+            self.full_name,
             self._serial,
             interface=self._interface,
             host=self._host,

--- a/src/zhinst/qcodes/control/drivers/shfqa.py
+++ b/src/zhinst/qcodes/control/drivers/shfqa.py
@@ -930,7 +930,7 @@ class SHFQA(ZIBaseInstrument):
 
         """
         self._controller = tk.SHFQA(
-            self._name,
+            self.full_name,
             self._serial,
             interface=self._interface,
             host=self._host,

--- a/src/zhinst/qcodes/control/drivers/shfsg.py
+++ b/src/zhinst/qcodes/control/drivers/shfsg.py
@@ -620,7 +620,7 @@ class SHFSG(ZIBaseInstrument):
 
         """
         self._controller = tk.SHFSG(
-            self._name,
+            self.full_name,
             self._serial,
             interface=self._interface,
             host=self._host,

--- a/src/zhinst/qcodes/control/drivers/uhfli.py
+++ b/src/zhinst/qcodes/control/drivers/uhfli.py
@@ -400,7 +400,7 @@ class UHFLI(ZIBaseInstrument):
 
         """
         self._controller = tk.UHFLI(
-            self._name,
+            self.full_name,
             self._serial,
             interface=self._interface,
             host=self._host,

--- a/src/zhinst/qcodes/control/drivers/uhfqa.py
+++ b/src/zhinst/qcodes/control/drivers/uhfqa.py
@@ -743,7 +743,7 @@ class UHFQA(ZIBaseInstrument):
 
         """
         self._controller = tk.UHFQA(
-            self._name,
+            self.full_name,
             self._serial,
             interface=self._interface,
             host=self._host,


### PR DESCRIPTION
_name has been removed and was private so should never have been used outside qcodes
The full_name attribute is equivalent to the name attribute for instruments but I have used the full_name for clarity 

Fixes https://github.com/zhinst/zhinst-qcodes/issues/27


