### PR TITLE
Rewrite the device stubs so they can be derived from

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # zhinst-qcodes Changelog
+## Version 0.3.3
+* Make device class stubs derivable. This enables the user to directly deriv
+  from the exposed classes.
 
 ## Version 0.3.2
 * Adapt to toolkit 0.3.1

--- a/docs/source/first_steps/quickstart.rst
+++ b/docs/source/first_steps/quickstart.rst
@@ -111,41 +111,6 @@ to have a separate session for a device one can use the ``new_session`` flag.
 But it is preferred to work in such cases with the session directly and not use
 the helper classes, since it is simpler to understand and recreate.
 
-Custom Device Classes
-----------------------
-Since the exposed helper classes only serve as a creator and can not be instantiated
-directly, it is **not** possible to derive from them directly.
-
-One needs to derive from the underlying device driver directly. The device drivers
-are located under ``zhinst.qcodes.driver.devices``.
-
-.. code-block:: python
-
-    >>> from zhinst.qcodes.driver.devices.shfqa import SHFQA as ZISHFQADriver
-    >>> class SHFQADriver(ZISHFQADriver):
-    >>>     def tester(self):
-    >>>         print("I am just a tester")
-
-Since the session takes care of the device object creation it needs to be made
-aware of the new class. This can easily be done be changing the underlying device
-mapping dictionary.
-
-.. code-block:: python
-
-    >>> from zhinst.qcodes.driver.devices import DEVICE_CLASS_BY_MODEL
-    >>> DEVICE_CLASS_BY_MODEL["SHFQA"] = SHFQADriver
-
-After that one can use the above described ways to create a device connection.
-For example, by using the exposed helper class:
-
-.. code-block:: python
-
-    >>> from zhinst.qcodes import SHFQA
-    >>> device = SHFQA("DEV1234", "localhost")
-    >>> device.tester()
-    I am just a tester
-
-
 Node Tree
 ---------
 

--- a/src/zhinst/qcodes/__init__.py
+++ b/src/zhinst/qcodes/__init__.py
@@ -2,16 +2,16 @@
 
 from zhinst.qcodes.session import ZISession
 from zhinst.qcodes.device_creator import (
-    ZIDevice as HDAWG,
-    ZIDevice as MFLI,
-    ZIDevice as MFIA,
-    ZIDevice as PQSC,
-    ZIDevice as SHFQA,
-    ZIDevice as SHFSG,
-    ZIDevice as UHFLI,
-    ZIDevice as UHFQA,
+    HDAWG,
+    MFLI,
+    MFIA,
+    PQSC,
+    SHFQA,
+    SHFSG,
+    UHFLI,
+    UHFQA,
     ZIDevice,
-    ZIDeviceHF2 as HF2,
+    HF2,
 )
 
 from zhinst.toolkit import (

--- a/src/zhinst/qcodes/device_creator.py
+++ b/src/zhinst/qcodes/device_creator.py
@@ -1,36 +1,30 @@
 """Helper class to directly create device instances
 
-The classes can be used withoutr creating as session to a data server first.
-The device classes only implement the __new__ magic function and return the
-created Instrument class object.
+The classes can be used without creating as session to a data server first.
 """
 from zhinst.qcodes.session import ZISession
 
+from zhinst.qcodes.driver.devices.base import ZIBaseInstrument
+from zhinst.qcodes.driver.devices.hdawg import HDAWG as HDAWGDriver
+from zhinst.qcodes.driver.devices.pqsc import PQSC as PQSCDriver
+from zhinst.qcodes.driver.devices.shfqa import SHFQA as SHFQADriver
+from zhinst.qcodes.driver.devices.shfsg import SHFSG as SHFSGDriver
+from zhinst.qcodes.driver.devices.uhfli import UHFLI as UHFLIDriver
+from zhinst.qcodes.driver.devices.uhfqa import UHFQA as UHFQADriver
 
-class ZIDevice:
-    """Zurich Instruments device driver.
 
-    This device driver works with all devices for Zurich Instrument.
-    Depending on the device type qcodes may offer special functionality. For
-    more information please take a look at the documentation.
-
-    Info:
-        Although we provide device specific classes for most of our devices the
-        underlying logic is exactly the same. Meaning the device specific
-        classes are just for visual purposes. The reason is that the object
-        creation, and mapping to the right device class happens inside the
-        data server session. For more information refer to the docuemtation.
-
+def zi_device(cls):
+    docstring = getattr(cls, "__doc__")
+    generic_docstring = f"""QCodes driver for the Zurich Instruments {cls.__name__}
     Args:
         serial: Serial number of the device, e.g. *'dev12000'*.
             The serial number can be found on the back panel of the instrument.
         server_host: Host address of the data server (e.g. localhost)
         server_port: Port number of the data server. If not specified the session
-            uses the default port 8004. (default = None)
+            uses the default port 8005. (default = None)
         interface: Device interface (e.g. = "1GbE"). If not specified
             the default interface from the discover is used.
         name: Name of the instrument in qcodes.
-            (default = "zi_{dev_type}_{serial}")
         raw: Flag if qcodes instance should only created with the nodes and
             not forwarding the toolkit functions. (default = False)
         new_session: By default zhinst-qcodes reuses already existing data
@@ -38,12 +32,14 @@ class ZIDevice:
             data server exists. Setting the Flag will create a new session.
 
             Warning:
-                Creating a new session should be done cearfully and reusing
-                the created sesison is not possible. Consider instantiating a
+                Creating a new session should be done carefully and reusing
+                the created session is not possible. Consider instantiating a
                 new session directly.
     """
+    cls.__doc__ = docstring if docstring else generic_docstring
+    orig_init = cls.__init__
 
-    def __new__(
+    def init(
         self,
         serial: str,
         host: str,
@@ -52,25 +48,67 @@ class ZIDevice:
         interface: str = None,
         name=None,
         raw=None,
-        new_session: bool = False
+        new_session: bool = False,
     ):
         session = ZISession(host, port, hf2=False, new_session=new_session)
-        return session.connect_device(serial, interface=interface, name=name, raw=raw)
+        tk_device = session.toolkit_session.connect_device(serial, interface=interface)
+        orig_init(self, tk_device, session, name=name, raw=raw)
+
+    cls.__init__ = init
+    return cls
 
 
-class ZIDeviceHF2:
-    """Zurich Instruments HF2 device driver.
+@zi_device
+class ZIDevice(ZIBaseInstrument):
+    pass
+
+
+@zi_device
+class HDAWG(HDAWGDriver):
+    pass
+
+
+@zi_device
+class MFLI(ZIBaseInstrument):
+    pass
+
+
+@zi_device
+class MFIA(ZIBaseInstrument):
+    pass
+
+
+@zi_device
+class PQSC(PQSCDriver):
+    pass
+
+
+@zi_device
+class SHFQA(SHFQADriver):
+    pass
+
+
+@zi_device
+class SHFSG(SHFSGDriver):
+    pass
+
+
+@zi_device
+class UHFLI(UHFLIDriver):
+    pass
+
+
+@zi_device
+class UHFQA(UHFQADriver):
+    pass
+
+
+class HF2(ZIBaseInstrument):
+    """QCoDeS driver for the *Zurich Instruments HF2*
 
     This device driver works with all HF2 devices for Zurich Instrument.
     Depending on the device type qcodes may offer special functionality. For
     more information please take a look at the documentation.
-
-    Info:
-        Although we provide device specific classes for most of our devices the
-        underlying logic is exactly the same. Meaning the device specific
-        classes are just for visual purposes. The reason is that the object
-        creation, and mapping to the right device class happens inside the
-        data server session. For more information refer to the docuemtation.
 
     Args:
         serial: Serial number of the device, e.g. *'dev12000'*.
@@ -89,12 +127,12 @@ class ZIDeviceHF2:
             data server exists. Setting the Flag will create a new session.
 
             Warning:
-                Creating a new session should be done cearfully and reusing
-                the created sesison is not possible. Consider instantiating a
+                Creating a new session should be done carefully and reusing
+                the created session is not possible. Consider instantiating a
                 new session directly.
     """
 
-    def __new__(
+    def __init__(
         self,
         serial: str,
         host: str,
@@ -103,7 +141,8 @@ class ZIDeviceHF2:
         interface: str = None,
         name=None,
         raw=None,
-        new_session: bool = False
+        new_session: bool = False,
     ):
         session = ZISession(host, port, hf2=True, new_session=new_session)
-        return session.connect_device(serial, interface=interface, name=name, raw=raw)
+        tk_device = session.toolkit_session.connect_device(serial, interface=interface)
+        super().__init__(tk_device, session, name, raw)

--- a/src/zhinst/qcodes/session.py
+++ b/src/zhinst/qcodes/session.py
@@ -665,3 +665,7 @@ class Session(ZIInstrument):
     def server_port(self) -> int:
         """Server port"""
         return self._tk_object.server_port
+
+    @property
+    def toolkit_session(self) -> TKSession:
+        return self._tk_object


### PR DESCRIPTION
Currently it was not possible to derive from the exposed device classes directly. One needed to derive from the underlying device classes hidden in the driver and replace the correct class in the session. To ease the use of our driver in custom packages this PR rewrites the device stubs so that they can be derived from.