### PR TITLE
Correct SHFSG4 instead of SHFSG

### DIFF
--- a/examples/test.spec.yml
+++ b/examples/test.spec.yml
@@ -14,4 +14,4 @@ shfqa_sweeper:
   device_type: "SHFQA2"
 
 shfsg_rabi:
-  device_type: "SHFSG"
+  device_type: "SHFSG4"


### PR DESCRIPTION
Correct SHFSG4 instead of SHFSG in test spec