### PR TITLE
Adapt zhinst-qcodes to poll changes in toolkit returning a string dict

### DIFF
--- a/src/zhinst/qcodes/device_creator.py
+++ b/src/zhinst/qcodes/device_creator.py
@@ -51,6 +51,7 @@ class ZIDevice(ZIBaseInstrument):
         session = ZISession(host, port, hf2=False, new_session=new_session)
         tk_device = session.toolkit_session.connect_device(serial, interface=interface)
         super().__init__(tk_device, session, name=name, raw=raw)
+        session.devices[self.serial] = self
 
 
 class SHFQA(SHFQADriver):
@@ -89,6 +90,7 @@ class SHFQA(SHFQADriver):
         session = ZISession(host, port, hf2=False, new_session=new_session)
         tk_device = session.toolkit_session.connect_device(serial, interface=interface)
         super().__init__(tk_device, session, name=name, raw=raw)
+        session.devices[self.serial] = self
 
 
 class SHFSG(SHFSGDriver):
@@ -127,6 +129,7 @@ class SHFSG(SHFSGDriver):
         session = ZISession(host, port, hf2=False, new_session=new_session)
         tk_device = session.toolkit_session.connect_device(serial, interface=interface)
         super().__init__(tk_device, session, name=name, raw=raw)
+        session.devices[self.serial] = self
 
 
 class HDAWG(HDAWGDriver):
@@ -165,6 +168,7 @@ class HDAWG(HDAWGDriver):
         session = ZISession(host, port, hf2=False, new_session=new_session)
         tk_device = session.toolkit_session.connect_device(serial, interface=interface)
         super().__init__(tk_device, session, name=name, raw=raw)
+        session.devices[self.serial] = self
 
 
 class PQSC(PQSCDriver):
@@ -203,6 +207,7 @@ class PQSC(PQSCDriver):
         session = ZISession(host, port, hf2=False, new_session=new_session)
         tk_device = session.toolkit_session.connect_device(serial, interface=interface)
         super().__init__(tk_device, session, name=name, raw=raw)
+        session.devices[self.serial] = self
 
 
 class SHFQC(SHFQCDriver):
@@ -241,6 +246,7 @@ class SHFQC(SHFQCDriver):
         session = ZISession(host, port, hf2=False, new_session=new_session)
         tk_device = session.toolkit_session.connect_device(serial, interface=interface)
         super().__init__(tk_device, session, name=name, raw=raw)
+        session.devices[self.serial] = self
 
 
 class UHFLI(UHFLIDriver):
@@ -279,6 +285,7 @@ class UHFLI(UHFLIDriver):
         session = ZISession(host, port, hf2=False, new_session=new_session)
         tk_device = session.toolkit_session.connect_device(serial, interface=interface)
         super().__init__(tk_device, session, name=name, raw=raw)
+        session.devices[self.serial] = self
 
 
 class UHFQA(UHFQADriver):
@@ -317,6 +324,7 @@ class UHFQA(UHFQADriver):
         session = ZISession(host, port, hf2=False, new_session=new_session)
         tk_device = session.toolkit_session.connect_device(serial, interface=interface)
         super().__init__(tk_device, session, name=name, raw=raw)
+        session.devices[self.serial] = self
 
 
 class MFLI(ZIBaseInstrument):
@@ -355,6 +363,7 @@ class MFLI(ZIBaseInstrument):
         session = ZISession(host, port, hf2=False, new_session=new_session)
         tk_device = session.toolkit_session.connect_device(serial, interface=interface)
         super().__init__(tk_device, session, name=name, raw=raw)
+        session.devices[self.serial] = self
 
 
 class MFIA(ZIBaseInstrument):
@@ -393,6 +402,7 @@ class MFIA(ZIBaseInstrument):
         session = ZISession(host, port, hf2=False, new_session=new_session)
         tk_device = session.toolkit_session.connect_device(serial, interface=interface)
         super().__init__(tk_device, session, name=name, raw=raw)
+        session.devices[self.serial] = self
 
 
 class HF2(ZIBaseInstrument):
@@ -431,3 +441,4 @@ class HF2(ZIBaseInstrument):
         session = ZISession(host, port, hf2=True, new_session=new_session)
         tk_device = session.toolkit_session.connect_device(serial, interface=interface)
         super().__init__(tk_device, session, name=name, raw=raw)
+        session.devices[self.serial] = self

--- a/src/zhinst/qcodes/session.py
+++ b/src/zhinst/qcodes/session.py
@@ -52,10 +52,12 @@ class Devices(MutableMapping):
             return self._devices[key]
         raise KeyError(key)
 
-    def __setitem__(self, *_):
-        raise LookupError(
-            "Illegal operation. Devices must be connected through the session."
-        )
+    def __setitem__(self, key: str, device: ZIDevices.DeviceType) -> None:
+        if device.serial not in self.connected():
+            raise LookupError(
+                "Illegal operation. Devices must be connected through the session."
+            )
+        self._devices[key] = device
 
     def __delitem__(self, key):
         self._devices.pop(key, None)
@@ -673,6 +675,7 @@ class Session(ZIInstrument):
         )
         polled_data = {}
         for tk_node, data in polled_data_tk.items():
+            tk_node = self._tk_object.raw_path_to_node(tk_node)
             device = self.devices[tk_node.root.prefix_hide]
             parameter = tk_node_to_parameter(device, tk_node)
             polled_data[parameter] = data


### PR DESCRIPTION
The latest toolkit changes return a string dict instead of a node dict when executing a poll. This enables to store the data without an active connection.
This MR adapts the qcodes driver to these changes.