### PR TITLE
Update links to QCoDeS docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Zurich Instruments Drivers for QCoDeS (zhinst-qcodes)
 The Zurich Instruments drivers for QCoDeS (zhinst-qcodes) is a package of
 instrument drivers for devices produced by [Zurich Instruments](https://www.zhinst.com)
-for QCoDeS. [QCoDeS](http://qcodes.github.io/Qcodes) is a Python-based data
+for QCoDeS. [QCoDeS](http://microsoft.github.io/Qcodes) is a Python-based data
 acquisition framework developed to serve the needs of nanoelectronic device
 experiments, but not limited to that. It is intended to be used within QCoDeS
 and not as standalone package. The QCoDeS instrument drivers are based on the

--- a/docs/source/first_steps/quickstart.rst
+++ b/docs/source/first_steps/quickstart.rst
@@ -119,7 +119,7 @@ hierarchical structure called the node tree. zhinst-qcodes implements the node t
 the by QCoDeS provided nested dictionary like structure. All leaf nodes are
 ``qcodes.instrument.parameter.Parameter`` nested in
 ``qcodes.instrument.baseInstrumentChannel`` s. Please refer to the
-`QCoDeS Documentation <https://qcodes.github.io/Qcodes//>`_ for a detailed
+`QCoDeS Documentation <https://microsoft.github.io/Qcodes//>`_ for a detailed
 explanation of Parameter work in QCoDeS.
 
 .. code-block:: python

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,7 +10,7 @@ Zurich Instruments QCoDeS driver |version| Documentation
 The Zurich Instruments drivers for QCoDeS (zhinst-qcodes) is a package of
 instrument drivers for devices produced by
 `Zurich Instruments <https://www.zhinst.com>`_ for QCoDeS.
-`QCoDeS <http://qcodes.github.io/Qcodes>`_ is a Python-based data acquisition
+`QCoDeS <http://microsoft.github.io/Qcodes>`_ is a Python-based data acquisition
 framework developed to serve the needs of nanoelectronic device experiments,
 but not limited to that.
 


### PR DESCRIPTION
We have moved QCoDeS to the Microsoft organization on Github. This updates links to the qcodes docs to reflect this.