### PR TITLE
Adapt scope example to address the change in scope module averager

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,3 +10,4 @@ jupytext==1.13.7
 ipython
 requests
 sphinxcontrib-spelling
+lxml_html_clean

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -83,7 +83,7 @@ html_theme = "pydata_sphinx_theme"
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
 
-html_css_files = ['zhinst-sphinx-theme/css/custom.css']
+html_css_files = ["zhinst-sphinx-theme/css/custom.css"]
 
 html_theme_options = {
     "logo": {
@@ -111,7 +111,13 @@ highlight_language = "none"
 
 # Spelling
 # sphinxcontrib.spelling configuration file
-spelling_word_list_filename='spelling_wordlist.txt'
+spelling_word_list_filename = "spelling_wordlist.txt"
 # Show suggestion in console output
-spelling_show_suggestions=False
-spelling_exclude_patterns=['examples/*.nblink', 'source/_static/zhinst-sphinx-theme/**/*']
+spelling_show_suggestions = False
+spelling_exclude_patterns = [
+    "examples/*.nblink",
+    "source/_static/zhinst-sphinx-theme/**/*",
+]
+
+# Warnings
+suppress_warnings = ["config.cache"]

--- a/examples/scope_module.md
+++ b/examples/scope_module.md
@@ -104,7 +104,6 @@ MIN_NUMBER_OF_RECORDS = 20
 
 scope_module = session.modules.scope
 scope_module.mode(1)
-scope_module.averager.weight(1)
 scope_module.historylength(20)
 scope_module.fft.window(0)
 ```


### PR DESCRIPTION
Removed the setting of averaging weight as it is no longer necessary for LabOne 24.07 and later. The consequence for LabOne 24.04 and before is that the user will see averaged results with an averaging weight of 10.