### PR TITLE
Drop python 3.7 support 

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,7 +39,7 @@ jobs:
           cd docs && make html EXAMPLE_SRC=remote
 
       - name: Store artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: docs
           path: docs/build/html

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.10
+        python-version: "3.10"
     - name: Install dependencies
       run:  pip install -U tox
     - name: Run Tox

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.10
     - name: Install dependencies
       run:  pip install -U tox
     - name: Run Tox

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,9 +14,6 @@ jobs:
     strategy:
       matrix:
         include:
-        - name: py37
-          python: 3.7
-          tox: py37
         - name: py38
           python: 3.8
           tox: py38

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@ project_urls =
 
 classifiers =
     Development Status :: 4 - Beta
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -27,7 +26,7 @@ classifiers =
 package_dir =
     = src
 packages = find_namespace:
-python_requires = >=3.7
+python_requires = >=3.8
 use_scm_version = True
 install_requires =
     numpy>=1.13

--- a/src/zhinst/qcodes/session.py
+++ b/src/zhinst/qcodes/session.py
@@ -501,7 +501,7 @@ class ZISession:
         *,
         hf2: t.Optional[bool] = None,
         new_session=False,
-        connection: ziDAQServer = None,
+        connection: ziDAQServer | None = None,
     ):
         """Session creator."""
         if not new_session:
@@ -561,7 +561,7 @@ class Session(ZIInstrument):
         server_port: t.Optional[int] = None,
         *,
         hf2: t.Optional[bool] = None,
-        connection: ziDAQServer = None,
+        connection: ziDAQServer | None = None,
     ):
         self._tk_object = TKSession(
             server_host, server_port, connection=connection, hf2=hf2

--- a/src/zhinst/qcodes/session.py
+++ b/src/zhinst/qcodes/session.py
@@ -501,7 +501,7 @@ class ZISession:
         *,
         hf2: t.Optional[bool] = None,
         new_session=False,
-        connection: ziDAQServer | None = None,
+        connection: t.Optional[ziDAQServer] = None,
     ):
         """Session creator."""
         if not new_session:
@@ -561,7 +561,7 @@ class Session(ZIInstrument):
         server_port: t.Optional[int] = None,
         *,
         hf2: t.Optional[bool] = None,
-        connection: ziDAQServer | None = None,
+        connection: t.Optional[ziDAQServer] = None,
     ):
         self._tk_object = TKSession(
             server_host, server_port, connection=connection, hf2=hf2

--- a/src/zhinst/qcodes/session.py
+++ b/src/zhinst/qcodes/session.py
@@ -1,12 +1,13 @@
 """Connection Manager for the LabOne Python API."""
+
 from collections.abc import MutableMapping
+from functools import cached_property
 import typing as t
 
 from zhinst.toolkit.session import Devices as TKDevices
 from zhinst.toolkit.session import PollFlags
 from zhinst.toolkit.session import Session as TKSession
 from zhinst.toolkit.session import ModuleHandler as TKModuleHandler
-from zhinst.toolkit.nodetree.helper import lazy_property
 from zhinst.core import ziDAQServer
 
 import zhinst.qcodes.driver.devices as ZIDevices
@@ -321,7 +322,7 @@ class ModuleHandler:
         module = self._tk_modules.create_shfqa_sweeper()
         return ZIModules.ZISHFQASweeper(module, self._session)
 
-    @lazy_property
+    @cached_property
     def awg(self) -> ZIModules.ZIBaseModule:
         """Managed instance of the zhinst.core.AwgModule.
 
@@ -332,7 +333,7 @@ class ModuleHandler:
         """
         return self.create_awg_module()
 
-    @lazy_property
+    @cached_property
     def daq(self) -> ZIModules.ZIBaseModule:
         """Managed instance of the zhinst.core.DataAcquisitionModule.
 
@@ -343,7 +344,7 @@ class ModuleHandler:
         """
         return self.create_daq_module()
 
-    @lazy_property
+    @cached_property
     def device_settings(self) -> ZIModules.ZIDeviceSettingsModule:
         """Managed instance of the zhinst.core.DeviceSettingsModule.
 
@@ -354,7 +355,7 @@ class ModuleHandler:
         """
         return self.create_device_settings_module()
 
-    @lazy_property
+    @cached_property
     def impedance(self) -> ZIModules.ZIImpedanceModule:
         """Managed instance of the zhinst.core.ImpedanceModule.
 
@@ -365,7 +366,7 @@ class ModuleHandler:
         """
         return self.create_impedance_module()
 
-    @lazy_property
+    @cached_property
     def mds(self) -> ZIModules.ZIBaseModule:
         """Managed instance of the zhinst.core.MultiDeviceSyncModule.
 
@@ -376,7 +377,7 @@ class ModuleHandler:
         """
         return self.create_mds_module()
 
-    @lazy_property
+    @cached_property
     def pid_advisor(self) -> ZIModules.ZIPIDAdvisorModule:
         """Managed instance of the zhinst.core.PidAdvisorModule.
 
@@ -387,7 +388,7 @@ class ModuleHandler:
         """
         return self.create_pid_advisor_module()
 
-    @lazy_property
+    @cached_property
     def precompensation_advisor(self) -> ZIModules.ZIPrecompensationAdvisorModule:
         """Managed instance of the zhinst.core.PrecompensationAdvisorModule.
 
@@ -398,7 +399,7 @@ class ModuleHandler:
         """
         return self.create_precompensation_advisor_module()
 
-    @lazy_property
+    @cached_property
     def qa(self) -> ZIModules.ZIBaseModule:
         """Managed instance of the zhinst.core.QuantumAnalyzerModule.
 
@@ -409,7 +410,7 @@ class ModuleHandler:
         """
         return self.create_qa_module()
 
-    @lazy_property
+    @cached_property
     def scope(self) -> ZIModules.ZIScopeModule:
         """Managed instance of the zhinst.core.ScopeModule.
 
@@ -420,7 +421,7 @@ class ModuleHandler:
         """
         return self.create_scope_module()
 
-    @lazy_property
+    @cached_property
     def sweeper(self) -> ZIModules.ZISweeperModule:
         """Managed instance of the zhinst.core.SweeperModule.
 
@@ -431,7 +432,7 @@ class ModuleHandler:
         """
         return self.create_sweeper_module()
 
-    @lazy_property
+    @cached_property
     def shfqa_sweeper(self) -> ZIModules.ZISHFQASweeper:
         """Managed instance of the zhinst.core.SweeperModule.
 

--- a/src/zhinst/qcodes/session.py
+++ b/src/zhinst/qcodes/session.py
@@ -199,7 +199,7 @@ class ModuleHandler:
         Returns:
             created module
         """
-        module = self._tk_modules.create_device_settings_module()
+        module = self._tk_modules.create_impedance_module()
         return ZIModules.ZIImpedanceModule(module, self._session)
 
     def create_mds_module(self) -> ZIModules.ZIBaseModule:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37, py38, py39, py310, lint, typing
+envlist = py38, py39, py310, lint, typing
 skip_missing_interpreters = true
 skipsdist = true
 # pyproject.toml: To use a PEP 517 build-backend you are required to configure tox to use an isolated_build
@@ -9,34 +9,34 @@ isolated_build = True
 basepython = python3
 
 [testenv]
-allowlist_externals = 
+allowlist_externals =
     flake8
     scripts/zhinst_qcodes_symlink.py
 deps =
-   py{37,38,39,310}: -rrequirements.txt
+   py{38,39,310}: -rrequirements.txt
    pytest-cov
-commands = 
+commands =
     # install toolkit first to ensure the correct version
-    {envpython} -m pip install git+https://github.com/zhinst/zhinst-toolkit 
+    {envpython} -m pip install git+https://github.com/zhinst/zhinst-toolkit
     {envpython} -m pip install .
     {envpython} scripts/zhinst_qcodes_symlink.py
     {envpython} -m pytest --cov=zhinst.qcodes
 
 [testenv:lint]
-deps = 
+deps =
     flake8
     flake8-docstrings
-commands = 
+commands =
     flake8
 
 [testenv:black]
-deps = 
+deps =
     black==22.3.0
-commands = 
+commands =
     black . --check --diff
 
 [testenv:typing]
-deps = 
+deps =
     mypy
-commands = 
+commands =
     mypy src


### PR DESCRIPTION
Closes https://github.com/zhinst/zhinst-qcodes/issues/43

QCoDeS dropped support quite a while ago and has also since dropped support for both 3.8 and 3.9. Happy to do a pr to drop those too and add testing with 3.11 and 3.12

Dropping 3.7 allows us to replace lazy_property with cached_property from the standard library. Lazy_propery is not currently typed but cached_property is so this resolves that the types members such as `mfli.session.modules.daq` are now resolved correctly as a zhinst module

While looking at that module I noticed 2 other typing related issues that I also fixed. In some instances implicit optional was still used so add an explicit None to the annotation. In `create_impedance_module` it looks like the wrong module was being created which does not match the return type

