### PR TITLE
Add python 3.11, 3.12 and drop 3.8 and 3.9

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
       - name: "Setup Python"
         uses: "actions/setup-python@v3"
         with:
-          python-version: "3.9"
+          python-version: "3.11"
 
       - name: "Install build dependencies"
         run: |
@@ -27,7 +27,7 @@ jobs:
           python -VV
           python -m site
           python -m pip install --upgrade pip setuptools wheel
-          python -m pip install git+https://github.com/zhinst/zhinst-toolkit 
+          python -m pip install git+https://github.com/zhinst/zhinst-toolkit
           python -m pip install --upgrade -r requirements.txt
           python -m pip install --upgrade -r docs/requirements.txt
           pip install .

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,7 @@
 name: Publish to PyPi
 on:
   push:
-    tags: 
+    tags:
     - "v*.*.*"
 
 jobs:
@@ -14,7 +14,7 @@ jobs:
       - name: "Setup Python"
         uses: "actions/setup-python@v3"
         with:
-          python-version: "3.9"
+          python-version: "3.11"
 
       - name: "Install build dependencies"
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,10 +24,13 @@ jobs:
         - name: py310
           python: "3.10"
           tox: py310
+        - name: py311
+          python: "3.11"
+          tox: py311
 
     steps:
       - uses: "actions/checkout@v2"
-      - uses: "actions/setup-python@v1"
+      - uses: "actions/setup-python@v4"
         with:
           python-version: "${{ matrix.python }}"
       - name: "Install dependencies"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,15 +14,9 @@ jobs:
     strategy:
       matrix:
         include:
-        - name: py38
-          python: 3.8
-          tox: py38
-        - name: py39
-          python: 3.9
-          coverage: true
-          tox: py39
         - name: py310
           python: "3.10"
+          coverage: true
           tox: py310
         - name: py311
           python: "3.11"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,9 @@ jobs:
         - name: py311
           python: "3.11"
           tox: py311
+        - name: py312
+          python: "3.12"
+          tox: py312
 
     steps:
       - uses: "actions/checkout@v2"

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,8 +14,6 @@ project_urls =
 
 classifiers =
     Development Status :: 4 - Beta
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
     Topic :: Scientific/Engineering

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ classifiers =
 package_dir =
     = src
 packages = find_namespace:
-python_requires = >=3.8
+python_requires = >=3.10
 use_scm_version = True
 install_requires =
     numpy>=1.13

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
     Topic :: Scientific/Engineering

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38, py39, py310, lint, typing
+envlist = py38, py39, py310, py311, lint, typing
 skip_missing_interpreters = true
 skipsdist = true
 # pyproject.toml: To use a PEP 517 build-backend you are required to configure tox to use an isolated_build
@@ -13,7 +13,7 @@ allowlist_externals =
     flake8
     scripts/zhinst_qcodes_symlink.py
 deps =
-   py{38,39,310}: -rrequirements.txt
+   py{38,39,310,311}: -rrequirements.txt
    pytest-cov
 commands =
     # install toolkit first to ensure the correct version

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38, py39, py310, py311, lint, typing
+envlist = py38, py39, py310, py311, py312, lint, typing
 skip_missing_interpreters = true
 skipsdist = true
 # pyproject.toml: To use a PEP 517 build-backend you are required to configure tox to use an isolated_build
@@ -13,7 +13,7 @@ allowlist_externals =
     flake8
     scripts/zhinst_qcodes_symlink.py
 deps =
-   py{38,39,310,311}: -rrequirements.txt
+   py{38,39,310,311,312}: -rrequirements.txt
    pytest-cov
 commands =
     # install toolkit first to ensure the correct version

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38, py39, py310, py311, py312, lint, typing
+envlist = py310, py311, py312, lint, typing
 skip_missing_interpreters = true
 skipsdist = true
 # pyproject.toml: To use a PEP 517 build-backend you are required to configure tox to use an isolated_build
@@ -13,7 +13,7 @@ allowlist_externals =
     flake8
     scripts/zhinst_qcodes_symlink.py
 deps =
-   py{38,39,310,311,312}: -rrequirements.txt
+   py{310,311,312}: -rrequirements.txt
    pytest-cov
 commands =
     # install toolkit first to ensure the correct version


### PR DESCRIPTION
Since QCoDeS no longer supports 3.8 and 3.9 this will drop these and test with 3.11 and 3.12 instead.

Includes changes from #58