### PR TITLE
Update qcodes imports.

### DIFF
--- a/generator/templates/instrument_class.py.j2
+++ b/generator/templates/instrument_class.py.j2
@@ -4,9 +4,9 @@ import re
 from typing import Union, Optional,List,Dict, Any, Tuple
 import deprecation
 import numpy as np
-from qcodes.instrument.channel import ChannelList
-from qcodes.instrument.parameter import Parameter as QCParameter
-from qcodes.utils.validators import ComplexNumbers
+from qcodes.instrument import ChannelList
+from qcodes.parameters import Parameter as QCParameter
+from qcodes.validators import ComplexNumbers
 from zhinst.toolkit.driver.devices.{{ name.lower() }} import {{ name }} as TK{{ name }}
 from zhinst.toolkit import CommandTable,Waveforms, Sequence
 from zhinst.toolkit.interface import AveragingMode, SHFQAChannelMode

--- a/generator/templates/module_class.py.j2
+++ b/generator/templates/module_class.py.j2
@@ -6,7 +6,7 @@ from zhinst.qcodes.driver.devices.base import ZIBaseInstrument
 from zhinst.toolkit.driver.modules import ModuleType as TKModuleType
 from zhinst.toolkit.driver.modules.{{ module_name }} import {{name}} as TK{{name}}
 from zhinst.toolkit.driver.modules.base_module import ZIModule
-from qcodes.instrument.base import Instrument
+from qcodes.instrument import Instrument
 {% if base_module != "ZIInstrument"%}
 from zhinst.qcodes.driver.modules.base_module import ZIBaseModule
 {% endif -%}

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ use_scm_version = True
 install_requires =
     numpy>=1.13
     zhinst-toolkit>=0.7.1
-    qcodes>=0.30.0
+    qcodes>=0.35.0
     typing_extensions>=4.1.1
 
 include_package_data = True

--- a/src/zhinst/qcodes/driver/devices/base.py
+++ b/src/zhinst/qcodes/driver/devices/base.py
@@ -7,7 +7,7 @@ from zhinst.qcodes.qcodes_adaptions import init_nodetree, ZIInstrument
 
 if t.TYPE_CHECKING:
     from zhinst.qcodes.session import ZISession, Session
-    from qcodes.instrument.base import Instrument
+    from qcodes.instrument import Instrument
 
 
 class ZIBaseInstrument(ZIInstrument):

--- a/src/zhinst/qcodes/qcodes_adaptions.py
+++ b/src/zhinst/qcodes/qcodes_adaptions.py
@@ -7,10 +7,9 @@ from contextlib import contextmanager, nullcontext
 from collections.abc import Mapping
 
 import numpy as np
-from qcodes.instrument.base import Instrument
-from qcodes.instrument.channel import ChannelList, InstrumentChannel
-from qcodes.instrument.parameter import Parameter
-from qcodes.utils.validators import ComplexNumbers
+from qcodes.instrument import ChannelList, Instrument, InstrumentChannel
+from qcodes.parameters import Parameter
+from qcodes.validators import ComplexNumbers
 from zhinst.toolkit.nodetree import Node, NodeTree
 from zhinst.toolkit.nodetree.helper import NodeDict as TKNodeDict
 from zhinst.toolkit.nodetree.node import NodeInfo


### PR DESCRIPTION
This updates qcodes imports to reflect the
currently supported and documented API.
Specifically the imports found in main
before this pr will be deprecated in the next
qcodes release (0.54.0). The current qcodes
api has been supported since qcodes 0.35.0.