### PR TITLE
Bump minimum zhinst-toolkit version to 1.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
   "numpy>=1.13",
-  "zhinst-toolkit>=0.7.1",
+  "zhinst-toolkit>=1.4.0",
   "qcodes>=0.35.0",
   "typing_extensions>=4.1.1",
 ]


### PR DESCRIPTION
zhinst-qcodes unconditionally requires `zhinst.toolkit.driver.modules.timeline_module`
added in version 1.4.0 of zhinst-toolkit.

To avoid this kind of issue in the future it would be nice zhinst-qcodes had a job that runs tests against the earliest 
supported versions of dependencies similar to what we do in qcodes here https://github.com/microsoft/Qcodes/blob/main/.github/workflows/pytest.yaml#L71