### PR TITLE
Stop loading MathJax and require.js from CDNs in the docs build

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -57,6 +57,15 @@ autosectionlabel_maxdepth = 2
 
 nbsphinx_execute = "never"
 
+# No notebook here contains real markdown-cell equations (the only `$...$`
+# occurrences are inside matplotlib axis-label strings, rendered by
+# matplotlib itself, not MathJax), and nbsphinx_execute="never" means no
+# interactive ipywidgets can exist either. Both defaults assume the worst
+# case and pull MathJax/require.js from a CDN on every page; disable them
+# to avoid the unvendored, unpinned external script load.
+nbsphinx_assume_equations = False
+nbsphinx_requirejs_path = ""
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 


### PR DESCRIPTION
## Summary
- `nbsphinx` defaults to assuming every notebook might contain equations and unconditionally injects `require.js` for Jupyter widgets, both currently loaded unpinned from `cdnjs.cloudflare.com` / `cdn.jsdelivr.net` with no integrity check — flagged by an MDN Observatory security scan of docs.zhinst.com (which mirrors these docs under `/zhinst-qcodes`).
- Neither CDN dependency is actually needed: `nbsphinx_execute="never"` means no widget can ever execute, and the only `$...$`-looking strings in the examples are matplotlib axis-label strings (e.g. `ax1.set_ylabel(r"Demodulator R ($V_\mathrm{RMS}$)")`), rendered by matplotlib itself at plot-generation time, not real markdown-cell math.
- Sets `nbsphinx_assume_equations = False` and `nbsphinx_requirejs_path = ""`.

## Test plan
- [x] Built the docs locally (`sphinx-build -b html source html`) and confirmed the output contains zero external `<script>`/`<link>` references (previously every page loaded MathJax + require.js from CDN regardless of content).
- [x] Confirmed code/output cell rendering in example notebook pages is unaffected (unrelated to MathJax).