### PR TITLE
Fix stale links to zhinst-toolkit's removed docs.zhinst.com docs

### DIFF
--- a/docs/source/examples/index.rst
+++ b/docs/source/examples/index.rst
@@ -7,7 +7,7 @@ The following section provides a set of examples.
 
    zhinst-qcodes is based on zhinst-toolkit. Meaning it has the same device
    specific functions and structure. Please take a look at the examples in the
-   `zhinst-toolkit examples <https://docs.zhinst.com/zhinst-toolkit/en/latest/examples/index.html>`_
+   `zhinst-toolkit examples <https://github.com/zhinst/zhinst-toolkit/tree/main/examples>`_
    for a more extensive list of examples.
 
 .. toctree::

--- a/docs/source/first_steps/quickstart.rst
+++ b/docs/source/first_steps/quickstart.rst
@@ -70,7 +70,7 @@ and has no logic builtin what so ever.
 For the device drivers this means that some device may have additional functionality
 provided by zhinst-toolkit. zhinst-qcodes forwards these functionalities.
 Please take a look at the examples in the
-`zhinst-toolkit examples <https://docs.zhinst.com/zhinst-toolkit/en/latest/examples/index.html>`_
+`zhinst-toolkit examples <https://github.com/zhinst/zhinst-toolkit/tree/main/examples>`_
 to see a list of all available functions. As already mentioned they can be used
 with the exact same syntax, which also is the case for all the examples from
 zhinst-toolkit (just replace the imports from zhinst-toolkit with zhinst-qcodes).
@@ -172,5 +172,5 @@ examples.
     <zhinst.core.DataAcquisitionModule at 0x10edc5630>
 
 Please take a look at the examples in the
-`zhinst-toolkit examples <https://docs.zhinst.com/zhinst-toolkit/en/latest/examples/index.html>`_
+`zhinst-toolkit examples <https://github.com/zhinst/zhinst-toolkit/tree/main/examples>`_
 to see some of the modules in action.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -22,10 +22,10 @@ zhinst-qcodes forwards all calls (functions, parameters ...) to zhinst qcodes
 and has no logic builtin what so ever.
 
 For the most cases the
-`zhinst-toolkit documentation <https://docs.zhinst.com/zhinst-toolkit/en/latest/>`_
+`zhinst-toolkit documentation <https://docs.zhinst.com/labone_api_user_manual/reference/toolkit/>`_
 will therefor serve as a reference for this package as well. If you can not find
 a answer to your question here please refer to the
-`zhinst-toolkit documentation <https://docs.zhinst.com/zhinst-toolkit/en/latest/>`_
+`zhinst-toolkit documentation <https://docs.zhinst.com/labone_api_user_manual/reference/toolkit/>`_
 instead.
 
 Get started with the :ref:`first_steps/installation:Installation` and then get

--- a/docs/source/package_documentation.rst
+++ b/docs/source/package_documentation.rst
@@ -23,7 +23,7 @@ zhinst-qcodes exposes the following classes:
    ~zhinst.qcodes.device_creator.GHFLI
 
 In addition the following classes are imported from
-`zhinst-toolkit <https://docs.zhinst.com/zhinst-toolkit/en/latest/package_documentation.html>`_:
+`zhinst-toolkit <https://docs.zhinst.com/labone_api_user_manual/reference/toolkit/>`_:
 
 * Waveforms
 * CommandTable


### PR DESCRIPTION
## Summary
- `zhinst-toolkit`'s Sphinx documentation was removed in 2025 in favor of the mkdocs-zhinst-based LabOne API User Manual (`docs.zhinst.com/labone_api_user_manual/reference/toolkit/`); the old `docs.zhinst.com/zhinst-toolkit/en/latest/` path is dead.
- Repoints the general "documentation" references (`docs/source/index.rst`, `docs/source/package_documentation.rst`) at the new location.
- Repoints the "examples" references (`docs/source/first_steps/quickstart.rst`, `docs/source/examples/index.rst`) at the GitHub examples folder directly, since example notebooks are no longer republished under docs.zhinst.com at all.
- `zhinst-qcodes`'s own docs (`docs.zhinst.com/zhinst-qcodes/...`) are still live and unaffected: only references to zhinst-toolkit's dead docs are touched here.

## Test plan
- [x] Grepped for `docs.zhinst.com/zhinst-toolkit` after the change: no remaining references.