### PR TITLE
Only bulk-read the node tree for a full snapshot

### DIFF
--- a/src/zhinst/qcodes/qcodes_adaptions.py
+++ b/src/zhinst/qcodes/qcodes_adaptions.py
@@ -16,6 +16,32 @@ from zhinst.toolkit.nodetree.helper import NodeDict as TKNodeDict
 from zhinst.toolkit.nodetree.node import NodeInfo
 
 
+def _is_full_snapshot_update(update: t.Optional[t.Union[bool, str]]) -> bool:
+    """Whether ``update`` requests a full refresh of every value.
+
+    The bulk node-tree read that :class:`ZISnapshotHelper` performs is only
+    appropriate for a *full* snapshot. A full snapshot corresponds to the legacy
+    ``update=True`` or, since QCoDeS 0.59, the canonical ``update="All"`` value.
+
+    Every other value must NOT trigger the bulk read:
+
+    * ``None`` / ``"Only_invalid"``: only refresh values whose cache is invalid,
+      which QCoDeS does one parameter at a time (and guards each with a
+      ``try/except``, so an unresponsive node degrades to its cached value).
+    * ``False`` / ``"Never"``: never read from the device at all.
+
+    Treating any truthy value as "full" is wrong for QCoDeS >= 0.59, whose
+    measurement ``Runner`` snapshots the station with the truthy *string*
+    ``"Only_invalid"`` before every dataset -- which previously forced a full
+    ``get("/dev.../*")`` read on every acquisition and could time out.
+
+    This check is intentionally version-agnostic (it accepts both the legacy
+    ``bool``/``None`` values and the QCoDeS >= 0.59 strings), so it does not
+    require raising the minimum supported QCoDeS version.
+    """
+    return update is True or update == "All"
+
+
 class ZISnapshotHelper:
     """Helper class for the snapshot with Zurich Instrument devices.
 
@@ -405,7 +431,11 @@ class ZINode(InstrumentChannel):
         Returns:
             dict: Base snapshot.
         """
-        with self._snapshot_cache.snapshot(self._zi_node) if update else nullcontext():
+        with (
+            self._snapshot_cache.snapshot(self._zi_node)
+            if _is_full_snapshot_update(update)
+            else nullcontext()
+        ):
             return super().snapshot(update)
 
     def print_readable_snapshot(self, update: bool = True, max_chars: int = 80) -> None:
@@ -424,7 +454,11 @@ class ZINode(InstrumentChannel):
                 readable snapshot will be cropped if this value is exceeded.
                 Defaults to 80 to be consistent with default terminal width.
         """
-        with self._snapshot_cache.snapshot(self._zi_node) if update else nullcontext():
+        with (
+            self._snapshot_cache.snapshot(self._zi_node)
+            if _is_full_snapshot_update(update)
+            else nullcontext()
+        ):
             return super().print_readable_snapshot(update, max_chars)
 
 
@@ -456,7 +490,11 @@ class ZIChannelList(ChannelList):
         Returns:
             dict: Base snapshot.
         """
-        with self._snapshot_cache.snapshot(self._zi_node) if update else nullcontext():
+        with (
+            self._snapshot_cache.snapshot(self._zi_node)
+            if _is_full_snapshot_update(update)
+            else nullcontext()
+        ):
             return super().snapshot(update)
 
     def print_readable_snapshot(self, update: bool = True, max_chars: int = 80) -> None:
@@ -475,7 +513,11 @@ class ZIChannelList(ChannelList):
                 readable snapshot will be cropped if this value is exceeded.
                 Defaults to 80 to be consistent with default terminal width.
         """
-        with self._snapshot_cache.snapshot(self._zi_node) if update else nullcontext():
+        with (
+            self._snapshot_cache.snapshot(self._zi_node)
+            if _is_full_snapshot_update(update)
+            else nullcontext()
+        ):
             return super().print_readable_snapshot(update, max_chars)
 
 
@@ -506,7 +548,11 @@ class ZIInstrument(Instrument):
         Returns:
             dict: Base snapshot.
         """
-        with self._snapshot_cache.snapshot() if update else nullcontext():
+        with (
+            self._snapshot_cache.snapshot()
+            if _is_full_snapshot_update(update)
+            else nullcontext()
+        ):
             return super().snapshot(update)
 
     def print_readable_snapshot(self, update: bool = True, max_chars: int = 80) -> None:
@@ -525,7 +571,11 @@ class ZIInstrument(Instrument):
                 readable snapshot will be cropped if this value is exceeded.
                 Defaults to 80 to be consistent with default terminal width.
         """
-        with self._snapshot_cache.snapshot() if update else nullcontext():
+        with (
+            self._snapshot_cache.snapshot()
+            if _is_full_snapshot_update(update)
+            else nullcontext()
+        ):
             return super().print_readable_snapshot(update, max_chars)
 
 

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -1,0 +1,138 @@
+"""Tests for snapshot ``update`` handling in the ZI qcodes adaptions.
+
+These cover the fix for the bulk node-tree read being performed for any truthy
+``update`` value: since QCoDeS 0.59 the measurement ``Runner`` snapshots the
+station with ``update="Only_invalid"`` (a truthy string) before every dataset,
+which previously forced a full ``get("/dev.../*")`` read on every acquisition
+and could time out. The bulk read must only happen for a full ("All"/``True``)
+snapshot.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from qcodes.instrument import Instrument
+
+from zhinst.qcodes.qcodes_adaptions import (
+    ZIInstrument,
+    ZINode,
+    ZIParameter,
+    _is_full_snapshot_update,
+)
+
+
+@pytest.mark.parametrize(
+    "update, expected",
+    [
+        (True, True),
+        ("All", True),
+        (None, False),
+        ("Only_invalid", False),
+        (False, False),
+        ("Never", False),
+    ],
+)
+def test_is_full_snapshot_update(update, expected):
+    assert _is_full_snapshot_update(update) is expected
+
+
+class _FakeConnection:
+    def __init__(self, value_map):
+        self._value_map = value_map
+        self.get_calls = []
+
+    def get(self, path, **kwargs):
+        self.get_calls.append(path)
+        return dict(self._value_map)
+
+
+class _FakeNodeTree:
+    def __init__(self, connection):
+        self.connection = connection
+        self.prefix_hide = ""
+
+
+@pytest.fixture()
+def instrument():
+    root_node = "/dev3000/oscs/0/freq"
+    child_node = "/dev3000/demods/0/rate"
+    connection = _FakeConnection(
+        {
+            root_node.lower(): {"value": [111]},
+            child_node.lower(): {"value": [222]},
+        }
+    )
+    instr = ZIInstrument("zi_snapshot_test", _FakeNodeTree(connection))
+
+    counters = {"root": 0, "child": 0}
+
+    def root_get():
+        counters["root"] += 1
+        return 1.0
+
+    def child_get():
+        counters["child"] += 1
+        return 2.0
+
+    instr.add_parameter(
+        "freq",
+        parameter_class=ZIParameter,
+        get_cmd=root_get,
+        set_cmd=lambda value: None,
+        snapshot_cache=instr._snapshot_cache,
+        zi_node=root_node,
+        tk_node=MagicMock(),
+    )
+    child = ZINode(
+        parent=instr,
+        name="demod0",
+        snapshot_cache=instr._snapshot_cache,
+        zi_node="/dev3000/demods/0",
+    )
+    instr.add_submodule("demod0", child)
+    child.add_parameter(
+        "rate",
+        parameter_class=ZIParameter,
+        get_cmd=child_get,
+        set_cmd=lambda value: None,
+        snapshot_cache=instr._snapshot_cache,
+        zi_node=child_node,
+        tk_node=MagicMock(),
+    )
+
+    yield instr, connection, counters
+    Instrument.close_all()
+
+
+@pytest.mark.parametrize("update", ["Only_invalid", None, "Never", False])
+def test_partial_snapshot_does_not_bulk_read(instrument, update):
+    instr, connection, _counters = instrument
+    instr.snapshot(update=update)
+    # No whole-tree ``get(".../*")`` at the instrument or submodule level.
+    assert connection.get_calls == []
+
+
+@pytest.mark.parametrize("update", ["Only_invalid", None])
+def test_only_invalid_reads_invalid_caches_individually(instrument, update):
+    instr, connection, counters = instrument
+    instr.snapshot(update=update)
+    assert connection.get_calls == []
+    # The invalid caches (root + submodule child) are refreshed one at a time.
+    assert counters["root"] == 1
+    assert counters["child"] == 1
+
+
+@pytest.mark.parametrize("update", ["All", True])
+def test_full_snapshot_uses_single_bulk_read(instrument, update):
+    instr, connection, counters = instrument
+    instr.snapshot(update=update)
+    assert len(connection.get_calls) == 1
+    # Values come from the bulk dict, so no per-parameter device reads.
+    assert counters["root"] == 0
+    assert counters["child"] == 0
+
+
+def test_bare_snapshot_defaults_to_full_read(instrument):
+    instr, connection, _counters = instrument
+    instr.snapshot()
+    assert len(connection.get_calls) == 1


### PR DESCRIPTION
Since QCoDeS 0.59 the measurement `Runner` snapshots the station with `update="Only_invalid"` before every dataset. `ZIInstrument` / `ZINode` / `ZIChannelList` `snapshot` (and `print_readable_snapshot`) gate the bulk `connection.get("/dev.../*")` read on `if update`, and `"Only_invalid"` is a truthy string — so a full-device read now runs on every acquisition and can time out on uninitialised nodes (`TimeoutError: Command timed out`). Since it runs outside `InstrumentBase.snapshot_base`'s per-parameter `try/except`, one bad node aborts the whole snapshot.

Gate the bulk read on a new `_is_full_snapshot_update` helper so it only runs for a full snapshot (`True` / `"All"`). `"Only_invalid"` / `None` refresh only the invalid caches individually; `"Never"` / `False` read nothing. The helper accepts both the legacy and the 0.59 values, so the minimum QCoDeS version is unchanged.
